### PR TITLE
Configure Whoosh index path via env var and run seed as django user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ help:
 seed-data:
 	@echo "Seeding bible data..."
 	python manage.py bible_to_redis apps/bible/data/bible.csv
-	python manage.py bible_to_haystack
+	sudo mkdir -p /var/lib/lamplight/whoosh
+  	sudo chown -R django:django /var/lib/lamplight
+	sudo -u django python manage.py bible_to_haystack
 
 .PHONY: lint
 lint:
@@ -38,5 +40,5 @@ status-check:
 	@echo "Checking status..."
 	sudo systemctl status grafana-server | head -n 4
 	sudo systemctl status nginx | head -n 4
-	sudo systemctl status gunicorn | head -n 4
+	sudo systemctl status granian | head -n 4
 	sudo systemctl status redis | head -n 4

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@ os-level dependencies
 `apk add python3 py3-pip py3-virtualenv git build-base python3-dev rust cargo libffi-dev certbot certbot-nginx nginx mariadb-connector-c-dev pkgconfig redis`
 
 ## virtual env
+```
 python3.12 -m venv .venv
 . .venv/bin/activate
 pip install pip-tools
+```
 
 ## Nginx Config(s)
-- etc/nginx/http.d/default.conf
+- `etc/nginx/http.d/default.conf`
 
 ```
 server {
@@ -35,16 +37,28 @@ server {
 ```
 
 ## Granian
+
+```
 /etc/init.d/granian
 chmod +x /etc/init.d/granian
 
 /etc/conf.d/granian (for exporting secret env vars)
+```
 
+```
+export DJANGO_SETTINGS_MODULE="lamplight.settings"
+export SECRET_KEY="____________"
+export DJANGO_DEBUG="0"
+export WHOOSH_INDEX_PATH=/var/lib/lamplight/whoosh
+```
+
+```
 rc-update add granian default
 rc-service granian start
+```
 
 ## view error logs
-tail -f /var/log/granian/granian.err
+`tail -f /var/log/granian/granian.err`
 
 ## Deploying python change(s)
 Granian provides a socket that launches the application's asgi.  Therefore, we need to reload the project:

--- a/lamplight/settings.py
+++ b/lamplight/settings.py
@@ -117,7 +117,7 @@ CACHES = {
 HAYSTACK_CONNECTIONS = {
     "default": {
         "ENGINE": "haystack.backends.whoosh_backend.WhooshEngine",
-        "PATH": str(BASE_DIR / "var" / "whoosh"),
+        "PATH": os.getenv("WHOOSH_INDEX_PATH", str(BASE_DIR / "var" / "whoosh")),
     },
 }
 HAYSTACK_SIGNAL_PROCESSOR = "haystack.signals.BaseSignalProcessor"


### PR DESCRIPTION
Move the Whoosh index out of the repo working tree to /var/lib/lamplight/whoosh so granian (running as the django user) can write to it. Also switch the status-check target from gunicorn to granian and tidy README code fences.