### PR TITLE
Source granian env when seeding Whoosh as django user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ seed-data:
 	python manage.py bible_to_redis apps/bible/data/bible.csv
 	sudo mkdir -p /var/lib/lamplight/whoosh
   	sudo chown -R django:django /var/lib/lamplight
-	sudo -u django python manage.py bible_to_haystack
+	su django -c '. /etc/conf.d/granian && python manage.py bible_to_haystack'
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lamplight-django
 os-level dependencies
-`apk add python3 py3-pip py3-virtualenv git build-base python3-dev rust cargo libffi-dev certbot certbot-nginx nginx mariadb-connector-c-dev pkgconfig redis`
+`apk add python3 py3-pip py3-virtualenv git build-base python3-dev rust cargo libffi-dev certbot certbot-nginx nginx mariadb-connector-c-dev pkgconfig redis sudo`
 
 ## virtual env
 ```


### PR DESCRIPTION
Why: bible_to_haystack needs WHOOSH_INDEX_PATH (and friends) from /etc/conf.d/granian to write to the shared index location. Also add sudo to the apk dependency list since seed-data shells out to it.