### PR TITLE
Add /ll/bible/<book>/<chapter>/<verse>/ verse browse endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint:
 	@echo "Linting..."
 	black .
 	isort .
-	find . -path ./.venv -prune -o -name '*.py' -exec pylint {} +
+	find . -path ./.venv -prune -o -path '*/migrations/*' -prune -o -name '*.py' -exec pylint {} +
 
 
 .PHONY: py-deps

--- a/apps/bible/management/commands/bible_to_haystack.py
+++ b/apps/bible/management/commands/bible_to_haystack.py
@@ -15,6 +15,9 @@ DEFAULT_JSON = DATA_DIR / "bible.json"
 
 
 class Command(BaseCommand):
+    # pylint: disable=no-member  # `self.style` exposes dynamic SUCCESS/WARNING attrs.
+    """Management command that builds the Whoosh index from bible.json."""
+
     help = "Seed the Whoosh search index with bible verses from bible.json."
 
     def add_arguments(self, parser):
@@ -37,55 +40,19 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        json_file = options["json_file"]
-        batch_size = options["batch_size"]
-        using = options["using"]
-
-        try:
-            with open(json_file, "r", encoding="utf-8") as fh:
-                entries = json.load(fh)
-        except FileNotFoundError as exc:
-            raise CommandError(f"JSON file not found: {json_file}") from exc
-        except json.JSONDecodeError as exc:
-            raise CommandError(f"Invalid JSON in {json_file}: {exc}") from exc
-
-        backend = connections[using].get_backend()
+        entries = self._load_entries(options["json_file"])
+        backend = connections[options["using"]].get_backend()
         backend.clear(models=[Verse], commit=True)
 
         index = VerseIndex()
         batch = []
         total = 0
+        batch_size = options["batch_size"]
         for entry in entries:
-            pk_id = entry.get("id")
-            text = entry.get("_text_", "")
-            if not pk_id:
+            verse = self._verse_from_entry(entry)
+            if verse is None:
                 continue
-
-            parts = pk_id.split(":")
-            if len(parts) != 4:
-                self.stderr.write(self.style.WARNING(f"skipping malformed id: {pk_id}"))
-                continue
-
-            version, book, chapter_s, verse_s = parts
-            try:
-                chapter = int(chapter_s)
-                verse_num = int(verse_s)
-            except ValueError:
-                self.stderr.write(
-                    self.style.WARNING(f"skipping non-int chapter/verse in: {pk_id}")
-                )
-                continue
-
-            batch.append(
-                Verse(
-                    pk_id=pk_id,
-                    version=version,
-                    book=book,
-                    chapter=chapter,
-                    verse=verse_num,
-                    text=text,
-                )
-            )
+            batch.append(verse)
 
             if len(batch) >= batch_size:
                 backend.update(index, batch, commit=False)
@@ -101,4 +68,45 @@ class Command(BaseCommand):
         backend.update(index, [], commit=True)
         self.stdout.write(
             self.style.SUCCESS(f"Haystack index seeded. {total} verses written.")
+        )
+
+    @staticmethod
+    def _load_entries(json_file):
+        try:
+            with open(json_file, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except FileNotFoundError as exc:
+            raise CommandError(f"JSON file not found: {json_file}") from exc
+        except json.JSONDecodeError as exc:
+            raise CommandError(f"Invalid JSON in {json_file}: {exc}") from exc
+
+    def _verse_from_entry(self, entry):
+        """Convert a bible.json entry into a Verse, or warn-and-skip if malformed."""
+
+        pk_id = entry.get("id")
+        if not pk_id:
+            return None
+
+        parts = pk_id.split(":")
+        if len(parts) != 4:
+            self.stderr.write(self.style.WARNING(f"skipping malformed id: {pk_id}"))
+            return None
+
+        version, book, chapter_s, verse_s = parts
+        try:
+            chapter = int(chapter_s)
+            verse_num = int(verse_s)
+        except ValueError:
+            self.stderr.write(
+                self.style.WARNING(f"skipping non-int chapter/verse in: {pk_id}")
+            )
+            return None
+
+        return Verse(
+            pk_id=pk_id,
+            version=version,
+            book=book,
+            chapter=chapter,
+            verse=verse_num,
+            text=entry.get("_text_", ""),
         )

--- a/apps/bible/management/commands/bible_to_redis.py
+++ b/apps/bible/management/commands/bible_to_redis.py
@@ -13,6 +13,9 @@ BOOK_MAP_PATH = DATA_DIR / "book_map.json"
 
 
 class Command(BaseCommand):
+    # pylint: disable=no-member  # `self.style` exposes dynamic SUCCESS/ERROR attrs.
+    """Management command that loads bible CSV verse data into Redis."""
+
     help = "Import bible CSV data into Redis hashes."
 
     def add_arguments(self, parser):

--- a/apps/bible/models.py
+++ b/apps/bible/models.py
@@ -17,6 +17,8 @@ class Verse(models.Model):
     verse = models.IntegerField()
     text = models.TextField()
 
-    class Meta:
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Django model metadata."""
+
         managed = False
         app_label = "bible"

--- a/apps/bible/schemas.py
+++ b/apps/bible/schemas.py
@@ -1,0 +1,46 @@
+"""Pydantic schemas used by the bible app's HTTP handlers."""
+
+from typing import Literal, Union
+
+from pydantic import BaseModel, Field, field_validator
+
+from .utilities import datasets
+
+
+class VersesQuery(BaseModel):
+    """Validated path + query params for the verses endpoint.
+
+    `book` is normalized to its short code; `chapter` and `verse` are either
+    a positive int or the wildcard string '*'.
+    """
+
+    book: str
+    chapter: Union[Literal["*"], int]
+    verse: Union[Literal["*"], int]
+    dataset: Literal["bible", "faves", "OT", "NT"] = "bible"
+    order: Literal["canonical", "random"] = "canonical"
+    version: Literal["nasb95"] = "nasb95"
+    limit: int = Field(default=25, ge=1, le=100)
+    page: int = Field(default=1, ge=1)
+    seed: Union[int, None] = Field(default=None, ge=0, le=2**31 - 1)
+
+    @field_validator("book")
+    @classmethod
+    def _resolve_book(cls, value):
+        code = datasets.resolve_book(value)
+        if code is None:
+            raise ValueError(f"unknown book: {value}")
+        return code
+
+    @field_validator("chapter", "verse", mode="before")
+    @classmethod
+    def _parse_int_or_wildcard(cls, value):
+        if value == "*":
+            return "*"
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("must be '*' or a positive integer") from exc
+        if parsed < 1:
+            raise ValueError("must be '*' or a positive integer")
+        return parsed

--- a/apps/bible/search_indexes.py
+++ b/apps/bible/search_indexes.py
@@ -12,6 +12,8 @@ from .models import Verse
 
 
 class VerseIndex(indexes.SearchIndex, indexes.Indexable):
+    """Whoosh schema for the Verse model; populated by bible_to_haystack."""
+
     text = indexes.CharField(document=True, use_template=False, model_attr="text")
     version = indexes.CharField(model_attr="version", faceted=True)
     book = indexes.CharField(model_attr="book", faceted=True)
@@ -22,4 +24,5 @@ class VerseIndex(indexes.SearchIndex, indexes.Indexable):
         return Verse
 
     def index_queryset(self, using=None):
+        # pylint: disable=no-member  # Django attaches `objects` dynamically.
         return Verse.objects.none()

--- a/apps/bible/urls.py
+++ b/apps/bible/urls.py
@@ -4,4 +4,11 @@ from django.urls import path
 
 from . import views
 
-urlpatterns = [path("search/", views.search, name="search")]
+urlpatterns = [
+    path("search/", views.search, name="search"),
+    path(
+        "bible/<str:book>/<str:chapter>/<str:verse>/",
+        views.verses,
+        name="verses",
+    ),
+]

--- a/apps/bible/utilities/bible_locator.py
+++ b/apps/bible/utilities/bible_locator.py
@@ -11,60 +11,63 @@ logger = logging.getLogger(__name__)
 
 
 def lookup(query, version="nasb95"):
-    """Search a string for an apparentl bible verse location in scripture."""
+    """Search a string for an apparent bible verse location in scripture."""
 
-    # check if the query is a specific bible resource
-    verse_matches = re.findall(
-        r"(\d*)[ ]*([a-zA-Z\s]+)[ ]*(-?\d+)\:?(-?\d*)", query.strip()
-    )
-    results = []
-    if verse_matches and (len(verse_matches[0]) == 4):
-        verse_matches = verse_matches[0]
+    matches = re.findall(r"(\d*)[ ]*([a-zA-Z\s]+)[ ]*(-?\d+)\:?(-?\d*)", query.strip())
+    if not matches or len(matches[0]) != 4:
+        return []
 
-        # normalize the string to avoid spelling/spacing/case inconsistencies
-        book = (verse_matches[0] + verse_matches[1]).strip().lower()
+    prefix_digits, name, chapter_str, verse_str = matches[0]
+    redis_conn = get_redis_connection("default")
+    book = _resolve_book(redis_conn, version, prefix_digits, name)
+    chapter = chapter_str if chapter_str else "1"
 
-        # find the mapping that fits best
-        redis_conn = get_redis_connection("default")
-        if not redis_conn.exists(f"{version}:{book}:1"):
-            book = (verse_matches[0] + " " + verse_matches[1]).strip().lower()
-            short_code = redis_conn.hget(f"{version}:books:{book}", "code")
-            if short_code:
-                book = short_code
-            else:
-                best_key = None
-                book_names = [
-                    key[len(f"{version}:books:") :]
-                    for key in redis_conn.scan_iter(match=f"{version}:books:*")
-                ]
+    if verse_str:
+        return [(version, book, chapter, verse_str)]
 
-                # is anything a prefix to the display name
-                if len(book) >= 3:
-                    for book_name in book_names:
-                        if book_name.startswith(book):
-                            best_key = book_name
-                            break
+    return [
+        (version, book, chapter, idx + 1)
+        for idx, _ in enumerate(
+            redis_conn.scan_iter(match=f"{version}:{book}:{chapter}:*")
+        )
+    ]
 
-                if not best_key:
-                    best_distance = 100
-                    # levenshtein the closest book name
-                    for book_name in book_names:
-                        dist = levenshtein.distance(book_name, book)
-                        if dist < best_distance:
-                            best_distance = dist
-                            best_key = book_name
 
-                if best_key:
-                    book = redis_conn.hget(f"{version}:books:{best_key}", "code")
+def _resolve_book(redis_conn, version, prefix_digits, name):
+    """Map a raw "1 john" / "luek" / "jhn" style fragment to a redis short code."""
 
-        chapter = verse_matches[2] if verse_matches[2] else "1"
+    candidate = (prefix_digits + name).strip().lower()
+    if redis_conn.exists(f"{version}:{candidate}:1"):
+        return candidate
 
-        if verse_matches[3]:
-            results.append((version, book, chapter, verse_matches[3]))
-        else:
-            for idx, _ in enumerate(
-                redis_conn.scan_iter(match=f"{version}:{book}:{chapter}:*")
-            ):
-                results.append((version, book, chapter, idx + 1))
+    spaced = (prefix_digits + " " + name).strip().lower()
+    short_code = redis_conn.hget(f"{version}:books:{spaced}", "code")
+    if short_code:
+        return short_code
 
-    return results
+    book_names = [
+        key[len(f"{version}:books:") :]
+        for key in redis_conn.scan_iter(match=f"{version}:books:*")
+    ]
+    best_key = _best_match(spaced, book_names)
+    if best_key:
+        return redis_conn.hget(f"{version}:books:{best_key}", "code")
+    return spaced
+
+
+def _best_match(book, book_names):
+    """Return the best display-name match for `book`, preferring prefix over levenshtein."""
+
+    if len(book) >= 3:
+        for name in book_names:
+            if name.startswith(book):
+                return name
+
+    best_key = None
+    best_distance = 100
+    for name in book_names:
+        dist = levenshtein.distance(name, book)
+        if dist < best_distance:
+            best_distance = dist
+            best_key = name
+    return best_key

--- a/apps/bible/utilities/datasets.py
+++ b/apps/bible/utilities/datasets.py
@@ -1,0 +1,179 @@
+"""Named verse datasets and book/path resolution for the verses endpoint.
+
+The bible structure (book -> chapter -> max verse) is built lazily from
+apps/bible/data/bible.json on first use and memoized per worker process.
+"""
+
+import json
+from functools import lru_cache
+from pathlib import Path
+
+from django.apps import apps
+
+DATA_DIR = Path(apps.get_app_config("bible").path) / "data"
+BOOK_MAP_PATH = DATA_DIR / "book_map.json"
+BIBLE_JSON_PATH = DATA_DIR / "bible.json"
+
+# Protestant canon: the first 39 entries of book_map.json are the OT.
+_OT_BOOK_COUNT = 39
+
+# Curated favorites — well-known verses surfaced by dataset=faves.
+FAVES = (
+    ("gen", 1, 1),
+    ("psa", 23, 1),
+    ("psa", 46, 10),
+    ("psa", 119, 105),
+    ("pro", 3, 5),
+    ("pro", 3, 6),
+    ("isa", 40, 31),
+    ("isa", 41, 10),
+    ("jer", 29, 11),
+    ("mat", 6, 33),
+    ("mat", 28, 19),
+    ("jhn", 1, 1),
+    ("jhn", 3, 16),
+    ("jhn", 14, 6),
+    ("act", 1, 8),
+    ("rom", 3, 23),
+    ("rom", 5, 8),
+    ("rom", 8, 28),
+    ("rom", 10, 9),
+    ("1co", 13, 4),
+    ("1co", 13, 13),
+    ("gal", 2, 20),
+    ("eph", 2, 8),
+    ("phl", 4, 13),
+    ("heb", 11, 1),
+    ("jas", 1, 5),
+    ("1jo", 4, 8),
+    ("rev", 3, 20),
+)
+
+
+@lru_cache(maxsize=1)
+def _book_map():
+    with open(BOOK_MAP_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@lru_cache(maxsize=1)
+def _codes_in_order():
+    return tuple(list(entry.values())[0] for entry in _book_map())
+
+
+@lru_cache(maxsize=1)
+def _display_name_by_code():
+    return {list(entry.values())[0]: list(entry.keys())[0] for entry in _book_map()}
+
+
+@lru_cache(maxsize=1)
+def _code_by_display_name():
+    return {list(entry.keys())[0]: list(entry.values())[0] for entry in _book_map()}
+
+
+@lru_cache(maxsize=1)
+def _structure():
+    """Return mapping {book_code: {chapter: max_verse}} from bible.json."""
+
+    with open(BIBLE_JSON_PATH, "r", encoding="utf-8") as f:
+        verses = json.load(f)
+
+    structure = {}
+    for entry in verses:
+        _, book, chapter, verse = entry["id"].split(":")
+        chapter = int(chapter)
+        verse = int(verse)
+        chapters = structure.setdefault(book, {})
+        if verse > chapters.get(chapter, 0):
+            chapters[chapter] = verse
+    return structure
+
+
+def _strip_non_alnum(s):
+    return "".join(ch for ch in s if ch.isalnum())
+
+
+def resolve_book(value):
+    """Normalize a path-provided book to its short code, or None if unknown.
+
+    Accepts the wildcard '*' (returned as-is), short codes ('gen'), and display
+    names with flexible spacing/case ('Genesis', '1 John', '1john', 'song-of-songs').
+    """
+
+    if value == "*":
+        return "*"
+
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+
+    if normalized in _display_name_by_code():
+        return normalized
+
+    name_to_code = _code_by_display_name()
+    if normalized in name_to_code:
+        return name_to_code[normalized]
+
+    stripped = _strip_non_alnum(normalized)
+    for display, code in name_to_code.items():
+        if _strip_non_alnum(display) == stripped:
+            return code
+    return None
+
+
+def display_name(book_code):
+    """Return the title-cased display name for a book short code."""
+
+    raw = _display_name_by_code().get(book_code, book_code)
+    return " ".join(word.capitalize() for word in raw.split(" "))
+
+
+def books_in_dataset(dataset):
+    """Ordered list of book codes belonging to the dataset (empty for 'faves')."""
+
+    codes = _codes_in_order()
+    if dataset == "bible":
+        return list(codes)
+    if dataset == "OT":
+        return list(codes[:_OT_BOOK_COUNT])
+    if dataset == "NT":
+        return list(codes[_OT_BOOK_COUNT:])
+    return []
+
+
+def _matches(ref, book, chapter, verse):
+    code, ch, v = ref
+    if book not in ("*", code):
+        return False
+    if chapter not in ("*", ch):
+        return False
+    if verse not in ("*", v):
+        return False
+    return True
+
+
+def enumerate_verses(dataset, book, chapter, verse):
+    """Yield (book_code, chapter, verse) triples matching the path filter.
+
+    Path values use '*' as a wildcard. Output is in canonical order
+    (book, then chapter, then verse). Pagination/shuffling is the caller's job.
+    """
+
+    if dataset == "faves":
+        for ref in FAVES:
+            if _matches(ref, book, chapter, verse):
+                yield ref
+        return
+
+    structure = _structure()
+    for code in books_in_dataset(dataset):
+        if book not in ("*", code):
+            continue
+        chapters = structure.get(code, {})
+        for ch in sorted(chapters):
+            if chapter not in ("*", ch):
+                continue
+            for v in range(1, chapters[ch] + 1):
+                if verse not in ("*", v):
+                    continue
+                yield (code, ch, v)

--- a/apps/bible/utilities/haystack_search.py
+++ b/apps/bible/utilities/haystack_search.py
@@ -37,6 +37,8 @@ def fulltext_lookup(query, limit=DEFAULT_LIMIT):
 
         term_hits = SearchQuerySet().filter(content=query)[:limit]
         return _hits_to_tuples(term_hits)
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
+        # Defensive: any backend failure (missing index, parse error, etc.)
+        # degrades to "no results" rather than 500ing the request.
         logger.exception("haystack fulltext lookup failed for query=%r", query)
         return []

--- a/apps/bible/views.py
+++ b/apps/bible/views.py
@@ -1,11 +1,15 @@
 """Implementations of various Bible handlers."""
 
 import logging
+import random
 
 from django.http import HttpResponse, JsonResponse
 from django_redis import get_redis_connection
 
-from .utilities import bible_locator, haystack_search
+from lamplight.decorators import validate_params
+
+from .schemas import VersesQuery
+from .utilities import bible_locator, datasets, haystack_search
 
 logger = logging.getLogger(__name__)
 
@@ -50,3 +54,60 @@ def search(request):
             )
 
     return JsonResponse({"data": data}, status=201)
+
+
+@validate_params(VersesQuery, path_fields=("book", "chapter", "verse"))
+def verses(request, params):  # pylint: disable=unused-argument
+    """Return a paginated list of verses matching the path + dataset filter.
+
+    Path segments accept '*' as a wildcard. Query params: dataset
+    (bible|faves|OT|NT, default bible), order (canonical|random, default
+    canonical), version (default nasb95), limit (default 25, max 100),
+    page (1-indexed, default 1).
+    """
+
+    pool = list(
+        datasets.enumerate_verses(
+            params.dataset, params.book, params.chapter, params.verse
+        )
+    )
+    if not pool:
+        return JsonResponse({"data": [], "nextPage": False})
+
+    seed = None
+    if params.order == "random":
+        seed = params.seed if params.seed is not None else random.randrange(2**31)
+        random.Random(seed).shuffle(pool)
+
+    start = (params.page - 1) * params.limit
+    selected = pool[start : start + params.limit]
+    next_page = start + params.limit < len(pool)
+
+    body = {
+        "data": _hydrate_verses(selected, params.version),
+        "nextPage": next_page,
+    }
+    if seed is not None:
+        body["seed"] = seed
+    return JsonResponse(body)
+
+
+def _hydrate_verses(refs, version):
+    """Look up verse text from Redis and shape the verse resource list."""
+
+    redis_conn = get_redis_connection("default")
+    data = []
+    for code, ch, v in refs:
+        text = redis_conn.hget(f"{version}:{code}:{ch}:{v}", "data")
+        if text is None:
+            logger.warning("redis missing verse %s:%s:%s:%s", version, code, ch, v)
+            continue
+        data.append(
+            {
+                "book": datasets.display_name(code),
+                "chapter": ch,
+                "verse": v,
+                "text": text,
+            }
+        )
+    return data

--- a/lamplight/decorators.py
+++ b/lamplight/decorators.py
@@ -1,0 +1,39 @@
+"""Project-wide view decorators."""
+
+from functools import wraps
+
+from django.http import JsonResponse
+from pydantic import ValidationError
+
+
+def validate_params(schema_cls, path_fields=()):
+    """Validate URL + query params against a pydantic schema before calling the view.
+
+    Path fields are pulled from the view's URL kwargs; the remaining schema
+    fields are read from request.GET. On success, the decorated view is called
+    as `view(request, params, ...)` where `params` is the validated schema
+    instance. On failure a 400 JsonResponse is returned with the first error.
+    """
+
+    def decorator(view):
+        @wraps(view)
+        def wrapper(request, *args, **kwargs):
+            payload = {
+                field: kwargs.pop(field) for field in path_fields if field in kwargs
+            }
+            for field in schema_cls.model_fields:
+                if field in payload:
+                    continue
+                if field in request.GET:
+                    payload[field] = request.GET[field]
+            try:
+                params = schema_cls.model_validate(payload)
+            except ValidationError as exc:
+                first = exc.errors()[0]
+                field = first["loc"][0] if first["loc"] else "input"
+                return JsonResponse({"error": f"{field}: {first['msg']}"}, status=400)
+            return view(request, params, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,7 @@ glom
 granian
 isort
 mysqlclient
+pydantic>=2
 pylint
 pytest-django
 python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements.in
 #
+annotated-types==0.7.0
+    # via pydantic
 asgiref==3.8.1
     # via django
 astroid==3.3.9
@@ -58,6 +60,7 @@ mysqlclient==2.2.7
 packaging==24.2
     # via
     #   black
+    #   django-haystack
     #   pytest
 pathspec==0.12.1
     # via black
@@ -67,6 +70,10 @@ platformdirs==4.3.7
     #   pylint
 pluggy==1.5.0
     # via pytest
+pydantic==2.13.4
+    # via -r requirements.in
+pydantic-core==2.46.4
+    # via pydantic
 pylint==3.3.6
     # via -r requirements.in
 pytest==8.3.5
@@ -85,6 +92,13 @@ sqlparse==0.5.3
     # via django
 tomlkit==0.13.2
     # via pylint
+typing-extensions==4.15.0
+    # via
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via pydantic
 urllib3==2.3.0
     # via requests
 uvloop==0.22.1

--- a/tests/test_bible_verses.py
+++ b/tests/test_bible_verses.py
@@ -1,0 +1,181 @@
+"""End-to-end tests for the /ll/bible/<book>/<chapter>/<verse>/ endpoint.
+
+Assumes Redis is seeded by `bible_to_redis` (same precondition as
+test_bible_search.py) so verse text lookups succeed.
+"""
+
+from urllib.parse import urlencode
+
+import pytest
+from django.urls import reverse
+
+
+def _url(book, chapter, verse, **params):
+    """Build a `verses` URL with optional query params."""
+
+    base = reverse("verses", kwargs={"book": book, "chapter": chapter, "verse": verse})
+    return f"{base}?{urlencode(params)}" if params else base
+
+
+@pytest.mark.parametrize(
+    "book,chapter,verse,expected_book",
+    [
+        ("john", "3", "16", "John"),
+        ("jhn", "3", "16", "John"),  # short code
+        ("1 John", "4", "8", "1 John"),  # display name with leading number
+        ("1john", "4", "8", "1 John"),  # no-space variant
+    ],
+)
+def test_specific_verse_resolves_book(client, book, chapter, verse, expected_book):
+    """Fully-specified paths return the right verse across book-name variants."""
+
+    response = client.get(_url(book, chapter, verse))
+    assert response.status_code == 200
+    body = response.json()
+    assert body["nextPage"] is False
+    assert len(body["data"]) == 1
+    item = body["data"][0]
+    assert item["book"] == expected_book
+    assert item["chapter"] == int(chapter)
+    assert item["verse"] == int(verse)
+    assert item["text"]
+
+
+@pytest.mark.parametrize(
+    "path,expected_count,expected_book",
+    [
+        (("john", "3", "*"), 36, "John"),  # full chapter (John 3 has 36 verses)
+        (("jude", "*", "*"), 25, "Jude"),  # full book (Jude is 1 chapter, 25 verses)
+    ],
+)
+def test_wildcards_expand_pool(client, path, expected_count, expected_book):
+    """`*` segments expand the pool to every matching verse."""
+
+    body = client.get(_url(*path, limit=100)).json()
+    assert len(body["data"]) == expected_count
+    assert body["nextPage"] is False
+    assert all(item["book"] == expected_book for item in body["data"])
+
+
+@pytest.mark.parametrize(
+    "page,expected_verses,expected_next",
+    [
+        (1, list(range(1, 11)), True),
+        (2, list(range(11, 21)), True),
+        (4, list(range(31, 37)), False),  # John 3 has 36 verses
+    ],
+)
+def test_pagination(client, page, expected_verses, expected_next):
+    """limit/page paginate the pool and nextPage flips on the last slice."""
+
+    body = client.get(_url("john", "3", "*", limit=10, page=page)).json()
+    assert [v["verse"] for v in body["data"]] == expected_verses
+    assert body["nextPage"] is expected_next
+
+
+@pytest.mark.parametrize(
+    "dataset,expected_book",
+    [("OT", "Genesis"), ("NT", "Matthew")],
+)
+def test_dataset_starts_at_first_book(client, dataset, expected_book):
+    """OT/NT iterate their books in canonical order from the first book."""
+
+    body = client.get(_url("*", "*", "*", dataset=dataset, limit=3)).json()
+    assert body["nextPage"] is True
+    assert body["data"][0]["book"] == expected_book
+    assert body["data"][0]["chapter"] == 1
+    assert body["data"][0]["verse"] == 1
+
+
+def test_explicit_version_param(client):
+    """Passing the only supported version explicitly returns the same payload."""
+
+    body = client.get(_url("john", "3", "16", version="nasb95")).json()
+    assert body["data"][0]["book"] == "John"
+    assert body["data"][0]["chapter"] == 3
+    assert body["data"][0]["verse"] == 16
+
+
+def test_dataset_faves(client):
+    """dataset=faves returns the curated list and respects book filters."""
+
+    all_faves = client.get(_url("*", "*", "*", dataset="faves", limit=100)).json()
+    refs = {(v["book"], v["chapter"], v["verse"]) for v in all_faves["data"]}
+    assert {("John", 3, 16), ("Genesis", 1, 1)}.issubset(refs)
+    assert all_faves["nextPage"] is False
+
+    only_john = client.get(_url("john", "*", "*", dataset="faves", limit=100)).json()
+    assert {v["book"] for v in only_john["data"]} == {"John"}
+
+    # Zechariah isn't in the faves list, so the filtered pool is empty.
+    empty = client.get(_url("zechariah", "*", "*", dataset="faves")).json()
+    assert empty == {"data": [], "nextPage": False}
+
+
+def test_order_random_returns_same_pool_in_different_order(client):
+    """order=random returns the same verses as canonical but shuffled."""
+
+    # John 3's 36 verses make accidental in-order shuffle vanishingly unlikely.
+    canonical = client.get(_url("john", "3", "*", limit=36)).json()
+    random_resp = client.get(_url("john", "3", "*", limit=36, order="random")).json()
+
+    canonical_refs = {(v["chapter"], v["verse"]) for v in canonical["data"]}
+    random_refs = {(v["chapter"], v["verse"]) for v in random_resp["data"]}
+    assert canonical_refs == random_refs
+    assert [v["verse"] for v in random_resp["data"]] != list(range(1, 37))
+    assert "seed" in random_resp
+    assert "seed" not in canonical
+
+
+def test_order_random_seed_enables_stable_pagination(client):
+    """Reusing the returned seed makes random pagination cover the pool without overlap."""
+
+    page1 = client.get(_url("john", "3", "*", limit=20, order="random")).json()
+    seed = page1["seed"]
+    assert page1["nextPage"] is True
+
+    page2 = client.get(
+        _url("john", "3", "*", limit=20, order="random", page=2, seed=seed)
+    ).json()
+    assert page2["seed"] == seed
+    assert page2["nextPage"] is False
+
+    combined = [(v["chapter"], v["verse"]) for v in page1["data"] + page2["data"]]
+    # John 3 has 36 verses; the two pages should partition the pool exactly once.
+    assert len(combined) == 36
+    assert set(combined) == {(3, v) for v in range(1, 37)}
+
+
+def test_order_random_same_seed_reproduces_order(client):
+    """Two random calls with the same seed return the same verse order."""
+
+    a = client.get(_url("john", "3", "*", limit=36, order="random", seed=42)).json()
+    b = client.get(_url("john", "3", "*", limit=36, order="random", seed=42)).json()
+    assert a["data"] == b["data"]
+    assert a["seed"] == b["seed"] == 42
+
+
+@pytest.mark.parametrize(
+    "path,params",
+    [
+        (("notabook", "1", "1"), {}),
+        (("john", "abc", "1"), {}),
+        (("john", "3", "16"), {"dataset": "bogus"}),
+        (("john", "3", "16"), {"order": "sideways"}),
+        (("john", "3", "16"), {"limit": "0"}),
+        (("john", "3", "16"), {"limit": "-1"}),
+        (("john", "3", "16"), {"limit": "101"}),
+        (("john", "3", "16"), {"limit": "abc"}),
+        (("john", "3", "16"), {"page": "0"}),
+        (("john", "3", "16"), {"page": "-1"}),
+        (("john", "3", "16"), {"page": "abc"}),
+        (("john", "3", "16"), {"version": "kjv"}),
+        (("john", "3", "16"), {"seed": "-1"}),
+        (("john", "3", "16"), {"seed": "abc"}),
+    ],
+)
+def test_invalid_input_returns_400(client, path, params):
+    """All input validation failures produce a 400."""
+
+    response = client.get(_url(*path, **params))
+    assert response.status_code == 400


### PR DESCRIPTION
Paginated GET endpoint that selects verses from a named dataset (bible|faves|OT|NT) with optional `*` wildcards in any path segment. order=random supports stable pagination by echoing a seed the client can pass back on subsequent pages.

Validation lives in a pydantic VersesQuery schema; a project-wide `validate_params` decorator (lamplight/decorators.py) pulls path fields from URL kwargs and the rest from request.GET so views stay pure.

Drive-by: refactor bible_locator/bible_to_haystack for complexity, add missing docstrings, exclude generated migrations from pylint, and add pydantic to requirements.