### PR TITLE
Zero-pad short concordance IDs and adopt pylint-django

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[MASTER]
+load-plugins=pylint_django
+django-settings-module=lamplight.settings

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ py-deps:
 	pip install -r requirements.txt
 
 
+.PHONY: py-install
+py-install:
+	@echo "Installing dependencies..."
+	pip install -r requirements.txt
+
+
 .PHONY: status-check
 status-check:
 	@echo "Checking status..."

--- a/apps/bible/management/commands/bible_to_haystack.py
+++ b/apps/bible/management/commands/bible_to_haystack.py
@@ -15,7 +15,6 @@ DEFAULT_JSON = DATA_DIR / "bible.json"
 
 
 class Command(BaseCommand):
-    # pylint: disable=no-member  # `self.style` exposes dynamic SUCCESS/WARNING attrs.
     """Management command that builds the Whoosh index from bible.json."""
 
     help = "Seed the Whoosh search index with bible verses from bible.json."

--- a/apps/bible/management/commands/bible_to_redis.py
+++ b/apps/bible/management/commands/bible_to_redis.py
@@ -13,7 +13,6 @@ BOOK_MAP_PATH = DATA_DIR / "book_map.json"
 
 
 class Command(BaseCommand):
-    # pylint: disable=no-member  # `self.style` exposes dynamic SUCCESS/ERROR attrs.
     """Management command that loads bible CSV verse data into Redis."""
 
     help = "Import bible CSV data into Redis hashes."

--- a/apps/bible/management/commands/concordance_to_db.py
+++ b/apps/bible/management/commands/concordance_to_db.py
@@ -16,7 +16,6 @@ BATCH_SIZE = 1000
 
 
 class Command(BaseCommand):
-    # pylint: disable=no-member  # `self.style` exposes dynamic SUCCESS/ERROR attrs.
     """Management command that loads concordance.json into the database."""
 
     help = "Import Strong's concordance JSON into the ConcordanceEntry table."

--- a/apps/bible/search_indexes.py
+++ b/apps/bible/search_indexes.py
@@ -24,5 +24,4 @@ class VerseIndex(indexes.SearchIndex, indexes.Indexable):
         return Verse
 
     def index_queryset(self, using=None):
-        # pylint: disable=no-member  # Django attaches `objects` dynamically.
         return Verse.objects.none()

--- a/apps/bible/views.py
+++ b/apps/bible/views.py
@@ -97,6 +97,9 @@ def verses(request, params):  # pylint: disable=unused-argument
 def concordance(request, concord_id):  # pylint: disable=unused-argument
     """Return the Strong's concordance entry for the given ID (e.g. G0001, H0001)."""
 
+    prefix, digits = concord_id[:1].upper(), concord_id[1:]
+    if prefix in ("G", "H") and digits.isdigit():
+        concord_id = f"{prefix}{int(digits):04d}"
     entry = get_object_or_404(ConcordanceEntry, pk=concord_id)
     return JsonResponse(ConcordanceEntryResponse.model_validate(entry).model_dump())
 

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ granian
 isort
 pydantic>=2
 pylint
+pylint-django
 pytest-django
 python-dotenv
 redis

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Shared pytest fixtures."""
+
+import pytest
+
+from apps.bible.models import ConcordanceEntry
+
+
+@pytest.fixture(scope="session")
+def django_db_setup(
+    django_db_setup, django_db_blocker
+):  # pylint: disable=redefined-outer-name,unused-argument
+    """Seed a handful of concordance entries once per session for endpoint tests."""
+
+    with django_db_blocker.unblock():
+        ConcordanceEntry.objects.bulk_create(
+            [
+                ConcordanceEntry(
+                    concord_id="G0001",
+                    original_word="ἄλφα",
+                    transliteration="alpha",
+                    part_of_speech="indeclinable noun",
+                    english_translations=[{"translation": "Alpha", "count": 4}],
+                    outline_definitions=["first letter of Greek alphabet"],
+                    strongs_definition=["†Α A, al'-fah"],
+                ),
+                ConcordanceEntry(
+                    concord_id="H0001",
+                    original_word="אָב",
+                    transliteration="ab",
+                    part_of_speech="noun masculine",
+                    english_translations=[{"translation": "father", "count": 1}],
+                    outline_definitions=["father of an individual"],
+                    strongs_definition=["אָב 'âb"],
+                ),
+                ConcordanceEntry(
+                    concord_id="H0734",
+                    original_word="אֹרַח",
+                    transliteration="ʼôrach",
+                    part_of_speech="noun masculine",
+                    english_translations=[{"translation": "way", "count": 1}],
+                    outline_definitions=["way, path"],
+                    strongs_definition=["אֹרַח 'ôrach"],
+                ),
+            ]
+        )

--- a/tests/test_bible_concordance.py
+++ b/tests/test_bible_concordance.py
@@ -1,26 +1,12 @@
 """End-to-end tests for the /ll/concordance/<concord_id>/ endpoint."""
 
-# pylint: disable=no-member  # Django ORM `objects` manager is added at class creation.
-
 import pytest
 from django.urls import reverse
-
-from apps.bible.models import ConcordanceEntry
 
 
 @pytest.mark.django_db
 def test_concordance_returns_entry(client):
     """A known concord_id returns 200 with the full serialized entry."""
-
-    ConcordanceEntry.objects.create(
-        concord_id="G0001",
-        original_word="ἄλφα",
-        transliteration="alpha",
-        part_of_speech="indeclinable noun",
-        english_translations=[{"translation": "Alpha", "count": 4}],
-        outline_definitions=["first letter of Greek alphabet"],
-        strongs_definition=["†Α A, al'-fah"],
-    )
 
     response = client.get(reverse("concordance", kwargs={"concord_id": "G0001"}))
     assert response.status_code == 200
@@ -41,3 +27,22 @@ def test_concordance_missing_id_returns_404(client):
 
     response = client.get(reverse("concordance", kwargs={"concord_id": "G9999"}))
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "concord_id, expected",
+    [
+        ("H734", "H0734"),
+        ("H1", "H0001"),
+        ("h1", "H0001"),
+        ("G1", "G0001"),
+        ("H0001", "H0001"),
+    ],
+)
+def test_concordance_zero_pads_short_ids(client, concord_id, expected):
+    """Short or lowercase IDs are normalized to the canonical 4-digit form."""
+
+    response = client.get(reverse("concordance", kwargs={"concord_id": concord_id}))
+    assert response.status_code == 200
+    assert response.json()["concord_id"] == expected


### PR DESCRIPTION
Normalize concord_id like H1/h1/H734 to the canonical 4-digit form (H0001, H0734) before lookup so the /ll/concordance/<id>/ endpoint works with either form. Add pylint-django so Django's dynamic attrs (`objects`, `self.style`) no longer trip pylint, and drop the now-unneeded no-member disables. Move the concordance test seed data into a session-scoped conftest fixture.