### PR TITLE
Clean cross-reference suffixes in concordance translations

### DIFF
--- a/apps/bible/data/concordance.json
+++ b/apps/bible/data/concordance.json
@@ -399,11 +399,11 @@
         "count": 14
       },
       {
-        "translation": "that which is good (with G3588)",
+        "translation": "that which is good",
         "count": 8
       },
       {
-        "translation": "the thing which is good (with G3588)",
+        "translation": "the thing which is good",
         "count": 1
       },
       {
@@ -632,7 +632,7 @@
         "count": 1
       },
       {
-        "translation": "charitably (with G2596)",
+        "translation": "charitably",
         "count": 1
       },
       {
@@ -2290,10 +2290,6 @@
       {
         "translation": "be an offender",
         "count": 1
-      },
-      {
-        "translation": "variations of 'hope'",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -2908,7 +2904,7 @@
         "count": 1
       },
       {
-        "translation": "to put away (with G1519)",
+        "translation": "to put away",
         "count": 1
       }
     ],
@@ -3054,7 +3050,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "goatskin (with G1192)",
+        "translation": "goatskin",
         "count": 1
       }
     ],
@@ -3337,7 +3333,7 @@
     "part_of_speech": "neuter noun",
     "english_translations": [
       {
-        "translation": "darkly (with G1722)",
+        "translation": "darkly",
         "count": 1
       }
     ],
@@ -4088,7 +4084,7 @@
         "count": 38
       },
       {
-        "translation": "never (with G3364) (with G1519) (with G3588)",
+        "translation": "never",
         "count": 6
       },
       {
@@ -4137,11 +4133,11 @@
         "count": 25
       },
       {
-        "translation": "the world began (with G5550)",
+        "translation": "the world began",
         "count": 2
       },
       {
-        "translation": "since the world began (with G5550)",
+        "translation": "since the world began",
         "count": 1
       },
       {
@@ -5015,7 +5011,7 @@
         "count": 2
       },
       {
-        "translation": "uncircumcised (with G2192)",
+        "translation": "uncircumcised",
         "count": 1
       },
       {
@@ -5092,7 +5088,7 @@
         "count": 1
       },
       {
-        "translation": "other (with G846)",
+        "translation": "other",
         "count": 1
       },
       {
@@ -5434,7 +5430,7 @@
         "count": 1
       },
       {
-        "translation": "born at Alexander (with G1085)",
+        "translation": "born at Alexander",
         "count": 1
       }
     ],
@@ -5524,7 +5520,7 @@
         "count": 107
       },
       {
-        "translation": "truly (with G1909)",
+        "translation": "truly",
         "count": 1
       },
       {
@@ -6383,7 +6379,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "to be taken (with G1519)",
+        "translation": "to be taken",
         "count": 1
       }
     ],
@@ -6792,7 +6788,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "secure (with G4060)",
+        "translation": "secure",
         "count": 1
       },
       {
@@ -7059,7 +7055,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "requite (with G591)",
+        "translation": "requite",
         "count": 1
       }
     ],
@@ -7395,11 +7391,11 @@
     "english_translations": [
       {
         "translation": "whosoever",
-        "count": 35
+        "count": 40
       },
       {
         "translation": "whatsoever",
-        "count": 7
+        "count": 19
       },
       {
         "translation": "whomsoever",
@@ -7414,43 +7410,27 @@
         "count": 1
       },
       {
-        "translation": "whatsoever (with G3745)",
-        "count": 7
-      },
-      {
-        "translation": "an many as (with G3745)",
+        "translation": "an many as",
         "count": 4
       },
       {
-        "translation": "whosoever (with G3745)",
-        "count": 2
-      },
-      {
-        "translation": "what things so ever (with G3745)",
+        "translation": "what things so ever",
         "count": 1
       },
       {
-        "translation": "wherewith soever (with G3745)",
+        "translation": "wherewith soever",
         "count": 1
       },
       {
-        "translation": "whithersoever (with G3699)",
+        "translation": "whithersoever",
         "count": 4
       },
       {
-        "translation": "wheresoever (with G3699)",
+        "translation": "wheresoever",
         "count": 2
       },
       {
-        "translation": "whatsoever (with G3748)",
-        "count": 5
-      },
-      {
-        "translation": "whosoever (with G3748)",
-        "count": 3
-      },
-      {
-        "translation": "whose soever (with G5100)",
+        "translation": "whose soever",
         "count": 2
       },
       {
@@ -7474,7 +7454,7 @@
     "english_translations": [
       {
         "translation": "by",
-        "count": 3
+        "count": 4
       },
       {
         "translation": "apiece",
@@ -7493,7 +7473,7 @@
         "count": 1
       },
       {
-        "translation": "two and two (with G1417)",
+        "translation": "two and two",
         "count": 1
       },
       {
@@ -7506,10 +7486,6 @@
       },
       {
         "translation": "between",
-        "count": 1
-      },
-      {
-        "translation": "by",
         "count": 1
       },
       {
@@ -7748,7 +7724,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "delay (with G4160)",
+        "translation": "delay",
         "count": 1
       }
     ],
@@ -7954,7 +7930,7 @@
         "count": 2
       },
       {
-        "translation": "need (with G2192)",
+        "translation": "need",
         "count": 1
       },
       {
@@ -8279,7 +8255,7 @@
         "count": 1
       },
       {
-        "translation": "bind under a great curse (with G332)",
+        "translation": "bind under a great curse",
         "count": 1
       }
     ],
@@ -8315,7 +8291,7 @@
         "count": 1
       },
       {
-        "translation": "bind under a great curse (with G331)",
+        "translation": "bind under a great curse",
         "count": 1
       }
     ],
@@ -8573,7 +8549,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "untaken away (with G3361)",
+        "translation": "untaken away",
         "count": 1
       },
       {
@@ -8980,7 +8956,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "lose saltness (with G1096)",
+        "translation": "lose saltness",
         "count": 1
       }
     ],
@@ -9223,7 +9199,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "can not be spoken against (with G5607)",
+        "translation": "can not be spoken against",
         "count": 1
       }
     ],
@@ -9304,11 +9280,7 @@
     "english_translations": [
       {
         "translation": "rest",
-        "count": 4
-      },
-      {
-        "translation": "rest (with G2192)",
-        "count": 1
+        "count": 5
       }
     ],
     "outline_definitions": [
@@ -9677,7 +9649,7 @@
         "count": 1
       },
       {
-        "translation": "raised to life again (with G1537)",
+        "translation": "raised to life again",
         "count": 1
       }
     ],
@@ -11056,7 +11028,7 @@
         "count": 1
       },
       {
-        "translation": "mankind (with G5449)",
+        "translation": "mankind",
         "count": 1
       }
     ],
@@ -11448,7 +11420,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "that (one) may open (with G1722)",
+        "translation": "that (one) may open",
         "count": 1
       }
     ],
@@ -11476,7 +11448,7 @@
         "count": 1
       },
       {
-        "translation": "transgress the law (with G4160)",
+        "translation": "transgress the law",
         "count": 1
       },
       {
@@ -11852,7 +11824,7 @@
         "count": 15
       },
       {
-        "translation": "because (with G3639)",
+        "translation": "because",
         "count": 4
       },
       {
@@ -11860,7 +11832,7 @@
         "count": 1
       },
       {
-        "translation": "therefore (with G3639)",
+        "translation": "therefore",
         "count": 1
       },
       {
@@ -12528,7 +12500,7 @@
     "part_of_speech": "neuter noun",
     "english_translations": [
       {
-        "translation": "nothing to draw with (with G3777)",
+        "translation": "nothing to draw with",
         "count": 1
       }
     ],
@@ -12857,7 +12829,7 @@
         "count": 1
       },
       {
-        "translation": "unworthy (with G3756)",
+        "translation": "unworthy",
         "count": 1
       }
     ],
@@ -12921,7 +12893,7 @@
         "count": 2
       },
       {
-        "translation": "after a godly sort (with G2316)",
+        "translation": "after a godly sort",
         "count": 1
       }
     ],
@@ -12991,10 +12963,6 @@
       {
         "translation": "show again",
         "count": 1
-      },
-      {
-        "translation": "variations of 'show'",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -13193,7 +13161,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "be alienated with (with G5607)",
+        "translation": "be alienated with",
         "count": 2
       },
       {
@@ -13260,7 +13228,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "to meet (with G1519)",
+        "translation": "to meet",
         "count": 4
       }
     ],
@@ -13774,7 +13742,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "cannot be tempted (with G2076)",
+        "translation": "cannot be tempted",
         "count": 1
       }
     ],
@@ -14408,7 +14376,7 @@
         "count": 6
       },
       {
-        "translation": "since (with G3739)",
+        "translation": "since",
         "count": 5
       },
       {
@@ -14947,7 +14915,7 @@
         "count": 1
       },
       {
-        "translation": "must put off (with G2076)",
+        "translation": "must put off",
         "count": 1
       }
     ],
@@ -15042,7 +15010,7 @@
         "count": 29
       },
       {
-        "translation": "at the point of death (with G3195)",
+        "translation": "at the point of death",
         "count": 1
       },
       {
@@ -15054,7 +15022,7 @@
         "count": 1
       },
       {
-        "translation": "slain (with G5408)",
+        "translation": "slain",
         "count": 1
       },
       {
@@ -15138,7 +15106,7 @@
         "count": 2
       },
       {
-        "translation": "to lighten (with G1519)",
+        "translation": "to lighten",
         "count": 1
       },
       {
@@ -15554,11 +15522,11 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "to enjoy (with G1519)",
+        "translation": "to enjoy",
         "count": 1
       },
       {
-        "translation": "enjoy the pleasures (with G2192)",
+        "translation": "enjoy the pleasures",
         "count": 1
       }
     ],
@@ -16255,7 +16223,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "to forsake (with G575)",
+        "translation": "to forsake",
         "count": 1
       },
       {
@@ -16541,11 +16509,11 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "be put out of the synagogue (with G1096)",
+        "translation": "be put out of the synagogue",
         "count": 2
       },
       {
-        "translation": "put out of the synagogue (with G4160)",
+        "translation": "put out of the synagogue",
         "count": 1
       }
     ],
@@ -17093,7 +17061,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "keep from falling (with G5442)",
+        "translation": "keep from falling",
         "count": 1
       }
     ],
@@ -17237,11 +17205,11 @@
         "count": 1
       },
       {
-        "translation": "to die (with G1519)",
+        "translation": "to die",
         "count": 1
       },
       {
-        "translation": "perish (with G1498) (with G1519)",
+        "translation": "perish",
         "count": 1
       },
       {
@@ -17290,27 +17258,27 @@
     "part_of_speech": "particle",
     "english_translations": [
       {
-        "translation": "therefore (with G3767)",
+        "translation": "therefore",
         "count": 7
       },
       {
-        "translation": "so then (with G3767)",
+        "translation": "so then",
         "count": 4
       },
       {
-        "translation": "now therefore (with G3767)",
+        "translation": "now therefore",
         "count": 1
       },
       {
-        "translation": "then (with G1065)",
+        "translation": "then",
         "count": 2
       },
       {
-        "translation": "wherefore (with G1065)",
+        "translation": "wherefore",
         "count": 1
       },
       {
-        "translation": "haply (with G1065)",
+        "translation": "haply",
         "count": 1
       },
       {
@@ -17671,7 +17639,7 @@
         "count": 1
       },
       {
-        "translation": "please (with G2076)",
+        "translation": "please",
         "count": 1
       },
       {
@@ -18381,11 +18349,7 @@
       },
       {
         "translation": "man child",
-        "count": 1
-      },
-      {
-        "translation": "man child (with G5207)",
-        "count": 1
+        "count": 2
       }
     ],
     "outline_definitions": [
@@ -18550,11 +18514,11 @@
         "count": 24
       },
       {
-        "translation": "henceforth (with G575)",
+        "translation": "henceforth",
         "count": 2
       },
       {
-        "translation": "hereafter (with G575)",
+        "translation": "hereafter",
         "count": 2
       },
       {
@@ -18562,7 +18526,7 @@
         "count": 2
       },
       {
-        "translation": "hitherto (with G2193)",
+        "translation": "hitherto",
         "count": 2
       },
       {
@@ -18637,7 +18601,7 @@
         "count": 23
       },
       {
-        "translation": "shewbread (with G4286) (with G3588)",
+        "translation": "shewbread",
         "count": 4
       }
     ],
@@ -18731,7 +18695,7 @@
         "count": 3
       },
       {
-        "translation": "a good while ago (with G575) (with G2250)",
+        "translation": "a good while ago",
         "count": 1
       }
     ],
@@ -20112,7 +20076,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "agreed not (with G5607)",
+        "translation": "agreed not",
         "count": 1
       }
     ],
@@ -20929,7 +20893,7 @@
         "count": 2
       },
       {
-        "translation": "sheepfold (with G4263)",
+        "translation": "sheepfold",
         "count": 1
       },
       {
@@ -21499,7 +21463,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "vanish out of sight (with G575)",
+        "translation": "vanish out of sight",
         "count": 1
       }
     ],
@@ -22058,7 +22022,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "the (one) foameth again (with G3326)",
+        "translation": "the (one) foameth again",
         "count": 1
       }
     ],
@@ -22078,7 +22042,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "foolishly (with G1722)",
+        "translation": "foolishly",
         "count": 2
       },
       {
@@ -22400,7 +22364,7 @@
     "english_translations": [
       {
         "translation": "until",
-        "count": 14
+        "count": 16
       },
       {
         "translation": "unto",
@@ -22408,18 +22372,10 @@
       },
       {
         "translation": "till",
-        "count": 3
+        "count": 6
       },
       {
-        "translation": "till (with G3739) (with G302)",
-        "count": 3
-      },
-      {
-        "translation": "until (with G3739)",
-        "count": 2
-      },
-      {
-        "translation": "while (with G3739)",
+        "translation": "while",
         "count": 2
       },
       {
@@ -22599,11 +22555,7 @@
       },
       {
         "translation": "deep",
-        "count": 1
-      },
-      {
-        "translation": "deep (with G2596)",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "deepness",
@@ -22635,7 +22587,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "dig deep (with G4626)",
+        "translation": "dig deep",
         "count": 1
       }
     ],
@@ -22661,7 +22613,7 @@
         "count": 2
       },
       {
-        "translation": "very early in the morning (with G3722)",
+        "translation": "very early in the morning",
         "count": 1
       }
     ],
@@ -22817,8 +22769,8 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "baptize (76)",
-        "count": null
+        "translation": "baptize",
+        "count": 76
       },
       {
         "translation": "wash",
@@ -22829,7 +22781,7 @@
         "count": 1
       },
       {
-        "translation": "baptized (with G2258)",
+        "translation": "baptized",
         "count": 1
       }
     ],
@@ -23180,7 +23132,7 @@
         "count": 4
       },
       {
-        "translation": "burdensome (with G1722)",
+        "translation": "burdensome",
         "count": 1
       },
       {
@@ -23495,7 +23447,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "king's court (with G3588)",
+        "translation": "king's court",
         "count": 1
       },
       {
@@ -23608,7 +23560,7 @@
         "count": 2
       },
       {
-        "translation": "king's country (with G3588)",
+        "translation": "king's country",
         "count": 1
       }
     ],
@@ -24326,7 +24278,7 @@
         "count": 1
       },
       {
-        "translation": "to set (one's) foot on (with G4128)",
+        "translation": "to set (one's) foot on",
         "count": 1
       }
     ],
@@ -25398,7 +25350,7 @@
         "count": 1
       },
       {
-        "translation": "advise (with G5087)",
+        "translation": "advise",
         "count": 1
       }
     ],
@@ -25752,15 +25704,11 @@
     "english_translations": [
       {
         "translation": "rain",
-        "count": 3
+        "count": 4
       },
       {
         "translation": "wash",
         "count": 2
-      },
-      {
-        "translation": "rain (with G5205)",
-        "count": 1
       },
       {
         "translation": "send rain",
@@ -26624,11 +26572,11 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "be with child (with G1722) (with G2192)",
+        "translation": "be with child",
         "count": 5
       },
       {
-        "translation": "with child (with G1722) (with G2192)",
+        "translation": "with child",
         "count": 2
       },
       {
@@ -26723,7 +26671,7 @@
         "count": 9
       },
       {
-        "translation": "hell fire (with G4442)",
+        "translation": "hell fire",
         "count": 3
       }
     ],
@@ -27402,7 +27350,7 @@
         "count": 1
       },
       {
-        "translation": "earthly (with G1537) (with G3588)",
+        "translation": "earthly",
         "count": 1
       }
     ],
@@ -27498,7 +27446,7 @@
         "count": 47
       },
       {
-        "translation": "God forbid (with G3361)",
+        "translation": "God forbid",
         "count": 15
       },
       {
@@ -27782,7 +27730,7 @@
         "count": 2
       },
       {
-        "translation": "purpose (with G1096)",
+        "translation": "purpose",
         "count": 1
       },
       {
@@ -27794,7 +27742,7 @@
         "count": 1
       },
       {
-        "translation": "agree (with G4160) (with G3391)",
+        "translation": "agree",
         "count": 1
       }
     ],
@@ -28123,7 +28071,7 @@
         "count": 7
       },
       {
-        "translation": "kneel (with G5087) (with G3588)",
+        "translation": "kneel",
         "count": 5
       }
     ],
@@ -28191,7 +28139,7 @@
         "count": 1
       },
       {
-        "translation": "written (with G1722)",
+        "translation": "written",
         "count": 1
       }
     ],
@@ -29244,10 +29192,6 @@
       {
         "translation": "miscellaneous",
         "count": 7
-      },
-      {
-        "translation": "variations of 'ought 1'",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -29544,7 +29488,7 @@
         "count": 24
       },
       {
-        "translation": "eighteen (with G2532) (with G3638)",
+        "translation": "eighteen",
         "count": 3
       }
     ],
@@ -29919,7 +29863,7 @@
     "part_of_speech": "neuter noun",
     "english_translations": [
       {
-        "translation": "skin (with G122)",
+        "translation": "skin",
         "count": 1
       }
     ],
@@ -30206,7 +30150,7 @@
         "count": 2
       },
       {
-        "translation": "hitherto (with G891) (with G3588)",
+        "translation": "hitherto",
         "count": 1
       }
     ],
@@ -30235,7 +30179,7 @@
         "count": 12
       },
       {
-        "translation": "follow (with G3694)",
+        "translation": "follow",
         "count": 1
       }
     ],
@@ -30302,20 +30246,12 @@
         "count": 34
       },
       {
-        "translation": "the second time (with G1537)",
-        "count": 4
-      },
-      {
         "translation": "the second time",
-        "count": 4
-      },
-      {
-        "translation": "again (with G1537)",
-        "count": 2
+        "count": 8
       },
       {
         "translation": "again",
-        "count": 1
+        "count": 3
       },
       {
         "translation": "secondarily",
@@ -30470,7 +30406,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "bewray (with G4160)",
+        "translation": "bewray",
         "count": 1
       },
       {
@@ -30695,7 +30631,7 @@
     "part_of_speech": "adverb",
     "english_translations": [
       {
-        "translation": "whatsoever (with G3769)",
+        "translation": "whatsoever",
         "count": 1
       }
     ],
@@ -30764,11 +30700,11 @@
         "count": 47
       },
       {
-        "translation": "therefore (with G5124)",
+        "translation": "therefore",
         "count": 44
       },
       {
-        "translation": "for this cause (with G5124)",
+        "translation": "for this cause",
         "count": 14
       },
       {
@@ -31107,7 +31043,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "lead a life (with G979)",
+        "translation": "lead a life",
         "count": 1
       },
       {
@@ -31208,7 +31144,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "come into (one's) room (with G2983)",
+        "translation": "come into (one's) room",
         "count": 1
       }
     ],
@@ -31999,7 +31935,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "beckoned (with G2258)",
+        "translation": "beckoned",
         "count": 1
       }
     ],
@@ -32094,7 +32030,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "continued all night (with G2258)",
+        "translation": "continued all night",
         "count": 1
       }
     ],
@@ -33361,7 +33297,7 @@
         "count": 93
       },
       {
-        "translation": "taught (with G2258)",
+        "translation": "taught",
         "count": 4
       }
     ],
@@ -33571,7 +33507,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "highway (with G3598) (with G3588)",
+        "translation": "highway",
         "count": 1
       }
     ],
@@ -33807,11 +33743,11 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "continually (with G1519)",
+        "translation": "continually",
         "count": 2
       },
       {
-        "translation": "for ever (with G1519)",
+        "translation": "for ever",
         "count": 2
       }
     ],
@@ -34165,7 +34101,7 @@
         "count": 1
       },
       {
-        "translation": "punish (with G5099)",
+        "translation": "punish",
         "count": 1
       }
     ],
@@ -35474,26 +35410,6 @@
     ]
   },
   {
-    "concord_id": "G1400",
-    "original_word": "δοῦλον",
-    "transliteration": "doulon",
-    "part_of_speech": "not applicable",
-    "english_translations": [
-      {
-        "translation": "no entry",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "Mr. Strong did not use number 1400"
-    ],
-    "strongs_definition": [
-      "δοῦλον doûlon, doo'-lon",
-      "neuter of G1401",
-      "subservient:—servant."
-    ]
-  },
-  {
     "concord_id": "G1401",
     "original_word": "δοῦλος",
     "transliteration": "doulos",
@@ -35724,7 +35640,7 @@
         "count": 100
       },
       {
-        "translation": "cannot (with G3756)",
+        "translation": "cannot",
         "count": 45
       },
       {
@@ -35974,7 +35890,7 @@
         "count": 2
       },
       {
-        "translation": "two and two (with G303)",
+        "translation": "two and two",
         "count": 1
       }
     ],
@@ -35985,27 +35901,6 @@
       "δύο dýo, doo'-o",
       "a primary numeral",
       "\"two\":—both, twain, two."
-    ]
-  },
-  {
-    "concord_id": "G1418",
-    "original_word": "δυσ-",
-    "transliteration": "dys-",
-    "part_of_speech": "prefix",
-    "english_translations": [
-      {
-        "translation": "none",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "prefix conveying the idea of difficulty, opposition, injuriousness, similar to our \"mis-\" or \"un-\" prefixes"
-    ],
-    "strongs_definition": [
-      "δυσ- dys-, doos",
-      "a primary inseparable particle of uncertain derivation",
-      "used only in composition as a prefix",
-      "hard, i.e. with difficulty:—+ hard, + grievous, etc."
     ]
   },
   {
@@ -36407,11 +36302,11 @@
         "count": 200
       },
       {
-        "translation": "whosoever (with G3769)",
+        "translation": "whosoever",
         "count": 14
       },
       {
-        "translation": "whatsoever (with G3739)",
+        "translation": "whatsoever",
         "count": 16
       },
       {
@@ -36535,7 +36430,7 @@
         "count": 1
       },
       {
-        "translation": "three score and fifteen (with G4002)",
+        "translation": "three score and fifteen",
         "count": 1
       }
     ],
@@ -37680,11 +37575,11 @@
         "count": 2
       },
       {
-        "translation": "- as his custom was (with G2596) (with G3588)",
+        "translation": "- as his custom was",
         "count": 1
       },
       {
-        "translation": "as his manner was (with G2596) (with G3588)",
+        "translation": "as his manner was",
         "count": 1
       }
     ],
@@ -37796,7 +37691,7 @@
     "english_translations": [
       {
         "translation": "or else",
-        "count": 3
+        "count": 4
       },
       {
         "translation": "else",
@@ -37804,19 +37699,11 @@
       },
       {
         "translation": "if not",
-        "count": 2
+        "count": 3
       },
       {
         "translation": "if otherwise",
         "count": 2
-      },
-      {
-        "translation": "if not",
-        "count": 1
-      },
-      {
-        "translation": "or else",
-        "count": 1
       },
       {
         "translation": "otherwise",
@@ -37880,7 +37767,7 @@
         "count": 31
       },
       {
-        "translation": "cannot tell (with G3756)",
+        "translation": "cannot tell",
         "count": 8
       },
       {
@@ -38402,7 +38289,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "I am (with G1473)",
+        "translation": "I am",
         "count": 74
       },
       {
@@ -38410,7 +38297,7 @@
         "count": 55
       },
       {
-        "translation": "it is I (with G1473)",
+        "translation": "it is I",
         "count": 6
       },
       {
@@ -38418,7 +38305,7 @@
         "count": 2
       },
       {
-        "translation": "I was (with G1473)",
+        "translation": "I was",
         "count": 1
       },
       {
@@ -39027,7 +38914,7 @@
         "count": 1
       },
       {
-        "translation": "to enter into (with G1519)",
+        "translation": "to enter into",
         "count": 1
       },
       {
@@ -39539,7 +39426,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "lighten the ship (with G4060)",
+        "translation": "lighten the ship",
         "count": 1
       }
     ],
@@ -39804,7 +39691,7 @@
         "count": 4
       },
       {
-        "translation": "avenge (with G4060)",
+        "translation": "avenge",
         "count": 3
       },
       {
@@ -40668,11 +40555,7 @@
     "english_translations": [
       {
         "translation": "faint",
-        "count": 5
-      },
-      {
-        "translation": "faint (with G2258)",
-        "count": 1
+        "count": 6
       }
     ],
     "outline_definitions": [
@@ -40778,7 +40661,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "willingly (with G2596)",
+        "translation": "willingly",
         "count": 1
       }
     ],
@@ -41206,7 +41089,7 @@
         "count": 3
       },
       {
-        "translation": "be amazed (with G3083)",
+        "translation": "be amazed",
         "count": 2
       },
       {
@@ -41331,7 +41214,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "instantly (with G1722)",
+        "translation": "instantly",
         "count": 1
       }
     ],
@@ -41490,15 +41373,15 @@
         "count": 1
       },
       {
-        "translation": "except (with G1508)",
+        "translation": "except",
         "count": 1
       },
       {
-        "translation": "unless (with G1508)",
+        "translation": "unless",
         "count": 1
       },
       {
-        "translation": "but (with G1508)",
+        "translation": "but",
         "count": 1
       }
     ],
@@ -41712,7 +41595,7 @@
         "count": 1
       },
       {
-        "translation": "exceedingly fear (with G1510)",
+        "translation": "exceedingly fear",
         "count": 1
       }
     ],
@@ -41758,7 +41641,7 @@
       },
       {
         "translation": "shed",
-        "count": 4
+        "count": 9
       },
       {
         "translation": "shed forth",
@@ -41766,15 +41649,11 @@
       },
       {
         "translation": "spill",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "run out",
         "count": 1
-      },
-      {
-        "translation": "shed",
-        "count": 5
       },
       {
         "translation": "run greedily",
@@ -41786,10 +41665,6 @@
       },
       {
         "translation": "gush out",
-        "count": 1
-      },
-      {
-        "translation": "spill",
         "count": 1
       }
     ],
@@ -42207,7 +42082,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "rebuke (with G2192)",
+        "translation": "rebuke",
         "count": 1
       }
     ],
@@ -43091,7 +42966,7 @@
         "count": 2
       },
       {
-        "translation": "take (with G1519)",
+        "translation": "take",
         "count": 2
       },
       {
@@ -43664,7 +43539,7 @@
         "count": 1
       },
       {
-        "translation": "entangle therein (with G5125)",
+        "translation": "entangle therein",
         "count": 1
       }
     ],
@@ -43919,7 +43794,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "show openly (with G1325) (with G1096)",
+        "translation": "show openly",
         "count": 1
       },
       {
@@ -43994,7 +43869,7 @@
         "count": 2
       },
       {
-        "translation": "tremble (with G1096)",
+        "translation": "tremble",
         "count": 1
       }
     ],
@@ -44318,12 +44193,8 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "to declare (with G1519)",
-        "count": 1
-      },
-      {
-        "translation": "to declare (with G4214)",
-        "count": 1
+        "translation": "to declare",
+        "count": 2
       },
       {
         "translation": "proof",
@@ -44723,7 +44594,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "laying with (with G4160)",
+        "translation": "laying with",
         "count": 1
       }
     ],
@@ -44807,7 +44678,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "such things as (one) has (with G3588)",
+        "translation": "such things as (one) has",
         "count": 1
       }
     ],
@@ -44839,11 +44710,11 @@
         "count": 2
       },
       {
-        "translation": "because (with G3739)",
+        "translation": "because",
         "count": 1
       },
       {
-        "translation": "wherefore (with G5101)",
+        "translation": "wherefore",
         "count": 1
       },
       {
@@ -45390,7 +45261,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "a great while before day (with G3129)",
+        "translation": "a great while before day",
         "count": 1
       }
     ],
@@ -45617,7 +45488,7 @@
         "count": 6
       },
       {
-        "translation": "on either side (with G2534)",
+        "translation": "on either side",
         "count": 4
       },
       {
@@ -45835,7 +45706,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "tremble (with G1096)",
+        "translation": "tremble",
         "count": 1
       },
       {
@@ -46613,7 +46484,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "accomplish (with G1096)",
+        "translation": "accomplish",
         "count": 1
       },
       {
@@ -47439,7 +47310,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "principal (with G2596)",
+        "translation": "principal",
         "count": 1
       }
     ],
@@ -47481,7 +47352,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "awake out of sleep (with G1096)",
+        "translation": "awake out of sleep",
         "count": 1
       }
     ],
@@ -48229,7 +48100,7 @@
         "count": 4
       },
       {
-        "translation": "thereon (with G846)",
+        "translation": "thereon",
         "count": 3
       },
       {
@@ -49001,7 +48872,7 @@
         "count": 1
       },
       {
-        "translation": "take (with G1519)",
+        "translation": "take",
         "count": 1
       },
       {
@@ -49225,11 +49096,11 @@
         "count": 1
       },
       {
-        "translation": "lay wait for (with G1096)",
+        "translation": "lay wait for",
         "count": 1
       },
       {
-        "translation": "lay wait (with G3195) (with G2071)",
+        "translation": "lay wait",
         "count": 1
       },
       {
@@ -49437,7 +49308,7 @@
         "count": 1
       },
       {
-        "translation": "with this inscription (with G1722) (with G3639)",
+        "translation": "with this inscription",
         "count": 1
       }
     ],
@@ -49561,7 +49432,7 @@
         "count": 1
       },
       {
-        "translation": "let drive (with G5342)",
+        "translation": "let drive",
         "count": 1
       },
       {
@@ -49802,7 +49673,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "lust after (with G1510)",
+        "translation": "lust after",
         "count": 1
       }
     ],
@@ -50337,7 +50208,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "refresh (one's) self (with G5177)",
+        "translation": "refresh (one's) self",
         "count": 1
       }
     ],
@@ -50632,26 +50503,6 @@
     ]
   },
   {
-    "concord_id": "G1970",
-    "original_word": "ἐπιπνίγω",
-    "transliteration": "epipnigō",
-    "part_of_speech": "verb",
-    "english_translations": [
-      {
-        "translation": "na",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "to throttle upon, to overgrow, to choke"
-    ],
-    "strongs_definition": [
-      "ἐπιπνίγω epipnígō, ep-ee-pnee'-go",
-      "from G1909 and G4155",
-      "to throttle upon, i.e. (figuratively) overgrow:—choke."
-    ]
-  },
-  {
     "concord_id": "G1971",
     "original_word": "ἐπιποθέω",
     "transliteration": "epipotheō",
@@ -50686,7 +50537,7 @@
         "count": 1
       },
       {
-        "translation": "longed after (with G2258)",
+        "translation": "longed after",
         "count": 1
       }
     ],
@@ -51379,7 +51230,7 @@
         "count": 1
       },
       {
-        "translation": "a raising up (with G4160)",
+        "translation": "a raising up",
         "count": 1
       }
     ],
@@ -52092,11 +51943,7 @@
     "english_translations": [
       {
         "translation": "anoint",
-        "count": 1
-      },
-      {
-        "translation": "anoint (with G1909)",
-        "count": 1
+        "count": 2
       }
     ],
     "outline_definitions": [
@@ -52232,7 +52079,7 @@
     "part_of_speech": "neuter noun",
     "english_translations": [
       {
-        "translation": "say (with G2036)",
+        "translation": "say",
         "count": 1
       }
     ],
@@ -52438,7 +52285,7 @@
         "count": 1
       },
       {
-        "translation": "forbear working (with G3361)",
+        "translation": "forbear working",
         "count": 1
       },
       {
@@ -52855,7 +52702,7 @@
         "count": 1
       },
       {
-        "translation": "contentious (with G1537)",
+        "translation": "contentious",
         "count": 1
       }
     ],
@@ -53327,7 +53174,7 @@
         "count": 49
       },
       {
-        "translation": "have hope (with G1679)",
+        "translation": "have hope",
         "count": 1
       },
       {
@@ -53639,7 +53486,7 @@
     "part_of_speech": "adverb",
     "english_translations": [
       {
-        "translation": "lie at the point of death (with G2292)",
+        "translation": "lie at the point of death",
         "count": 1
       }
     ],
@@ -54313,7 +54160,7 @@
         "count": 3
       },
       {
-        "translation": "please well (with G1510)",
+        "translation": "please well",
         "count": 1
       },
       {
@@ -54379,7 +54226,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "nobleman (with G444)",
+        "translation": "nobleman",
         "count": 1
       },
       {
@@ -54485,7 +54332,7 @@
         "count": 2
       },
       {
-        "translation": "seem good (with G1096)",
+        "translation": "seem good",
         "count": 2
       },
       {
@@ -54712,7 +54559,7 @@
         "count": 1
       },
       {
-        "translation": "governor (with G3588)",
+        "translation": "governor",
         "count": 1
       }
     ],
@@ -55064,7 +54911,7 @@
         "count": 2
       },
       {
-        "translation": "bountifully (with G1909)",
+        "translation": "bountifully",
         "count": 2
       },
       {
@@ -55346,7 +55193,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "his ability (with G5100)",
+        "translation": "his ability",
         "count": 1
       }
     ],
@@ -55430,7 +55277,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "that (one) may attend upon (with G4314) (with G3588)",
+        "translation": "that (one) may attend upon",
         "count": 1
       }
     ],
@@ -56590,7 +56437,7 @@
         "count": 22
       },
       {
-        "translation": "need (with G5532)",
+        "translation": "need",
         "count": 12
       },
       {
@@ -56629,7 +56476,7 @@
     "english_translations": [
       {
         "translation": "till",
-        "count": 28
+        "count": 39
       },
       {
         "translation": "unto",
@@ -56642,10 +56489,6 @@
       {
         "translation": "to",
         "count": 16
-      },
-      {
-        "translation": "till (with G3739)",
-        "count": 11
       },
       {
         "translation": "miscellaneous",
@@ -57638,7 +57481,7 @@
     "part_of_speech": "adverb",
     "english_translations": [
       {
-        "translation": "surely (with G3375)",
+        "translation": "surely",
         "count": 1
       }
     ],
@@ -58139,7 +57982,7 @@
         "count": 2
       },
       {
-        "translation": "us-ward (with G1519)",
+        "translation": "us-ward",
         "count": 2
       },
       {
@@ -58195,7 +58038,7 @@
         "count": 355
       },
       {
-        "translation": "daily (with G2596)",
+        "translation": "daily",
         "count": 15
       },
       {
@@ -58263,11 +58106,11 @@
         "count": 13
       },
       {
-        "translation": "I imprisoned (with G1473) (with G5439)",
+        "translation": "I imprisoned",
         "count": 1
       },
       {
-        "translation": "I was (with G1473)",
+        "translation": "I was",
         "count": 1
       },
       {
@@ -58435,11 +58278,11 @@
         "count": 11
       },
       {
-        "translation": "taught (with G1321)",
+        "translation": "taught",
         "count": 4
       },
       {
-        "translation": "stood (with G2476)",
+        "translation": "stood",
         "count": 4
       },
       {
@@ -58570,19 +58413,11 @@
     "part_of_speech": "proper masculine noun",
     "english_translations": [
       {
-        "translation": "Herod",
-        "count": null
-      },
-      {
-        "translation": "Antipas",
+        "translation": "Herod, Antipas",
         "count": 27
       },
       {
-        "translation": "Herod",
-        "count": null
-      },
-      {
-        "translation": "the Great",
+        "translation": "Herod, the Great",
         "count": 11
       },
       {
@@ -59083,11 +58918,11 @@
     "part_of_speech": "masculine/neuter noun",
     "english_translations": [
       {
-        "translation": "be amazed (with G1096)",
+        "translation": "be amazed",
         "count": 1
       },
       {
-        "translation": "be astonished (with G4023)",
+        "translation": "be astonished",
         "count": 1
       },
       {
@@ -59903,7 +59738,7 @@
         "count": 3
       },
       {
-        "translation": "God-ward (with G4214)",
+        "translation": "God-ward",
         "count": 2
       },
       {
@@ -60702,7 +60537,7 @@
         "count": 1
       },
       {
-        "translation": "to be afflicted (with G1519)",
+        "translation": "to be afflicted",
         "count": 1
       }
     ],
@@ -60760,7 +60595,7 @@
         "count": 5
       },
       {
-        "translation": "mortality (with G3588)",
+        "translation": "mortality",
         "count": 1
       }
     ],
@@ -61422,7 +61257,7 @@
         "count": 2
       },
       {
-        "translation": "that keeps the door (with G3588)",
+        "translation": "that keeps the door",
         "count": 2
       }
     ],
@@ -61776,7 +61611,7 @@
         "count": 1
       },
       {
-        "translation": "to heal (with G1519)",
+        "translation": "to heal",
         "count": 1
       },
       {
@@ -63441,11 +63276,7 @@
         "count": 1
       },
       {
-        "translation": "Justus (Jesus",
-        "count": null
-      },
-      {
-        "translation": "a fellow worker of Paul)",
+        "translation": "Justus (Jesus, a fellow worker of Paul)",
         "count": 1
       }
     ],
@@ -63638,11 +63469,11 @@
         "count": 1
       },
       {
-        "translation": "agree (with G2132)",
+        "translation": "agree",
         "count": 1
       },
       {
-        "translation": "give thyself wholly to (with G1722)",
+        "translation": "give thyself wholly to",
         "count": 1
       },
       {
@@ -63692,7 +63523,7 @@
         "count": 4
       },
       {
-        "translation": "agree together (with G2258)",
+        "translation": "agree together",
         "count": 2
       },
       {
@@ -63979,7 +63810,7 @@
         "count": 1
       },
       {
-        "translation": "mightily (with G1722)",
+        "translation": "mightily",
         "count": 1
       },
       {
@@ -64024,7 +63855,7 @@
         "count": 2
       },
       {
-        "translation": "cannot (with G3756)",
+        "translation": "cannot",
         "count": 1
       },
       {
@@ -64873,7 +64704,7 @@
         "count": 1
       },
       {
-        "translation": "purge (with G4060)",
+        "translation": "purge",
         "count": 1
       },
       {
@@ -65444,7 +65275,7 @@
         "count": 1
       },
       {
-        "translation": "as well as (with G2532)",
+        "translation": "as well as",
         "count": 1
       }
     ],
@@ -65700,7 +65531,7 @@
         "count": 2
       },
       {
-        "translation": "always (with G1722) (with G3956)",
+        "translation": "always",
         "count": 2
       },
       {
@@ -65833,7 +65664,7 @@
         "count": 10
       },
       {
-        "translation": "did burn (with G2258)",
+        "translation": "did burn",
         "count": 1
       },
       {
@@ -66174,7 +66005,7 @@
         "count": 2
       },
       {
-        "translation": "that which is evil (with G3458)",
+        "translation": "that which is evil",
         "count": 2
       },
       {
@@ -66301,11 +66132,11 @@
     "part_of_speech": "adverb",
     "english_translations": [
       {
-        "translation": "be sick (with G2192)",
+        "translation": "be sick",
         "count": 7
       },
       {
-        "translation": "be diseased (with G2192)",
+        "translation": "be diseased",
         "count": 2
       },
       {
@@ -66329,7 +66160,7 @@
         "count": 1
       },
       {
-        "translation": "sick people (with G2192)",
+        "translation": "sick people",
         "count": 1
       }
     ],
@@ -66432,7 +66263,7 @@
         "count": 1
       },
       {
-        "translation": "named (with G3686)",
+        "translation": "named",
         "count": 1
       },
       {
@@ -67051,7 +66882,7 @@
         "count": 159
       },
       {
-        "translation": "broken hearted (with G4937)",
+        "translation": "broken hearted",
         "count": 1
       }
     ],
@@ -67260,7 +67091,7 @@
         "count": 27
       },
       {
-        "translation": "daily (with G2250)",
+        "translation": "daily",
         "count": 15
       },
       {
@@ -67449,7 +67280,7 @@
         "count": 10
       },
       {
-        "translation": "to conceive (with G1519)",
+        "translation": "to conceive",
         "count": 1
       }
     ],
@@ -67928,7 +67759,7 @@
         "count": 1
       },
       {
-        "translation": "sat down (with G2258)",
+        "translation": "sat down",
         "count": 1
       }
     ],
@@ -68673,7 +68504,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "abode (with G2258)",
+        "translation": "abode",
         "count": 1
       }
     ],
@@ -69064,11 +68895,7 @@
     "english_translations": [
       {
         "translation": "swallow",
-        "count": 4
-      },
-      {
-        "translation": "swallow",
-        "count": 1
+        "count": 5
       },
       {
         "translation": "drown",
@@ -70928,7 +70755,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "to be burned (with G1519)",
+        "translation": "to be burned",
         "count": 1
       }
     ],
@@ -71970,7 +71797,7 @@
     "part_of_speech": "neuter noun",
     "english_translations": [
       {
-        "translation": "honeycomb (with G3193)",
+        "translation": "honeycomb",
         "count": 1
       }
     ],
@@ -72044,7 +71871,7 @@
         "count": 2
       },
       {
-        "translation": "preached (with G2258)",
+        "translation": "preached",
         "count": 2
       },
       {
@@ -73613,7 +73440,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "chamberlain (with G1909)",
+        "translation": "chamberlain",
         "count": 1
       }
     ],
@@ -74080,7 +73907,7 @@
     "part_of_speech": "adverb",
     "english_translations": [
       {
-        "translation": "bring to amend (with G2192)",
+        "translation": "bring to amend",
         "count": 1
       }
     ],
@@ -74245,7 +74072,7 @@
         "count": 13
       },
       {
-        "translation": "trouble (with G3830)",
+        "translation": "trouble",
         "count": 5
       },
       {
@@ -74279,7 +74106,7 @@
         "count": 1
       },
       {
-        "translation": "dung (with G906)",
+        "translation": "dung",
         "count": 1
       }
     ],
@@ -75045,7 +74872,7 @@
         "count": 1
       },
       {
-        "translation": "mighty (with G2596)",
+        "translation": "mighty",
         "count": 1
       }
     ],
@@ -75351,11 +75178,11 @@
         "count": 1
       },
       {
-        "translation": "go to law (with G2192)",
+        "translation": "go to law",
         "count": 1
       },
       {
-        "translation": "avenge (with G2919)",
+        "translation": "avenge",
         "count": 1
       }
     ],
@@ -77692,7 +77519,7 @@
         "count": 2
       },
       {
-        "translation": "want (with G1722)",
+        "translation": "want",
         "count": 1
       },
       {
@@ -78092,7 +77919,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "forget (with G3083)",
+        "translation": "forget",
         "count": 1
       }
     ],
@@ -78113,11 +77940,7 @@
     "english_translations": [
       {
         "translation": "winepress",
-        "count": 4
-      },
-      {
-        "translation": "winepress (with G3631)",
-        "count": 1
+        "count": 5
       }
     ],
     "outline_definitions": [
@@ -78209,7 +78032,7 @@
         "count": 4
       },
       {
-        "translation": "very chiefest (with G5228)",
+        "translation": "very chiefest",
         "count": 2
       },
       {
@@ -78404,11 +78227,11 @@
         "count": 4
       },
       {
-        "translation": "stumbling stone (with G4348)",
+        "translation": "stumbling stone",
         "count": 2
       },
       {
-        "translation": "mill stone (with G3457)",
+        "translation": "mill stone",
         "count": 1
       }
     ],
@@ -78481,7 +78304,7 @@
         "count": 2
       },
       {
-        "translation": "the fair havens (with G2570)",
+        "translation": "the fair havens",
         "count": 1
       }
     ],
@@ -79003,7 +78826,7 @@
         "count": 2
       },
       {
-        "translation": "to speak reproachfully (with G5484)",
+        "translation": "to speak reproachfully",
         "count": 1
       }
     ],
@@ -79135,11 +78958,11 @@
         "count": 1
       },
       {
-        "translation": "moreover (with G1161) (with G3739)",
+        "translation": "moreover",
         "count": 1
       },
       {
-        "translation": "it remains (with G2076)",
+        "translation": "it remains",
         "count": 1
       },
       {
@@ -79490,7 +79313,7 @@
         "count": 1
       },
       {
-        "translation": "grudging (with G1537)",
+        "translation": "grudging",
         "count": 1
       },
       {
@@ -79678,7 +79501,7 @@
         "count": 2
       },
       {
-        "translation": "redeem (with G4160)",
+        "translation": "redeem",
         "count": 1
       }
     ],
@@ -80653,7 +80476,7 @@
         "count": 12
       },
       {
-        "translation": "better (with G2570)",
+        "translation": "better",
         "count": 2
       },
       {
@@ -82377,7 +82200,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "honeycomb (with G2781)",
+        "translation": "honeycomb",
         "count": 1
       }
     ],
@@ -82879,7 +82702,7 @@
         "count": 4
       },
       {
-        "translation": "to be partaker (with G1519)",
+        "translation": "to be partaker",
         "count": 1
       }
     ],
@@ -83115,11 +82938,11 @@
         "count": 6
       },
       {
-        "translation": "from among (with G1537)",
+        "translation": "from among",
         "count": 5
       },
       {
-        "translation": "midnight (with G3571)",
+        "translation": "midnight",
         "count": 2
       },
       {
@@ -83281,11 +83104,11 @@
         "count": 5
       },
       {
-        "translation": "hereafter (with G5023)",
+        "translation": "hereafter",
         "count": 4
       },
       {
-        "translation": "afterward (with G5023)",
+        "translation": "afterward",
         "count": 4
       },
       {
@@ -83563,7 +83386,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "to be received (with G1519)",
+        "translation": "to be received",
         "count": 1
       }
     ],
@@ -84189,14 +84012,10 @@
       },
       {
         "translation": "till",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "to",
-        "count": 1
-      },
-      {
-        "translation": "till (with G3739)",
         "count": 1
       }
     ],
@@ -84228,7 +84047,7 @@
         "count": 21
       },
       {
-        "translation": "God forbid (with G1096)",
+        "translation": "God forbid",
         "count": 15
       },
       {
@@ -84240,7 +84059,7 @@
         "count": 7
       },
       {
-        "translation": "no man (with G5100)",
+        "translation": "no man",
         "count": 6
       },
       {
@@ -84285,7 +84104,7 @@
         "count": 16
       },
       {
-        "translation": "whosoever not (with G3739)",
+        "translation": "whosoever not",
         "count": 5
       },
       {
@@ -84333,7 +84152,7 @@
         "count": 6
       },
       {
-        "translation": "that nothing (with G5100)",
+        "translation": "that nothing",
         "count": 1
       },
       {
@@ -84373,11 +84192,11 @@
         "count": 6
       },
       {
-        "translation": "never (with G1519) (with G165) (with G3588)",
+        "translation": "never",
         "count": 6
       },
       {
-        "translation": "no more at all (with G2089)",
+        "translation": "no more at all",
         "count": 5
       },
       {
@@ -84682,7 +84501,7 @@
     "part_of_speech": "particle",
     "english_translations": [
       {
-        "translation": "surely (with G2229)",
+        "translation": "surely",
         "count": 1
       }
     ],
@@ -84784,7 +84603,7 @@
         "count": 1
       },
       {
-        "translation": "lest haply (with G2443)",
+        "translation": "lest haply",
         "count": 1
       },
       {
@@ -85077,21 +84896,6 @@
       "μητρόπολις mētrópolis, may-trop'-ol-is",
       "from G3384 and G4172",
       "a mother city, i.e. \"metropolis\":—chiefest city."
-    ]
-  },
-  {
-    "concord_id": "G3391",
-    "original_word": "μία",
-    "transliteration": "mia",
-    "part_of_speech": "adjective",
-    "english_translations": [],
-    "outline_definitions": [
-      "only one, someone"
-    ],
-    "strongs_definition": [
-      "μία mía, mee'-ah",
-      "irregular feminine of G1520",
-      "one or first:—a (certain), + agree, first, one, × other."
     ]
   },
   {
@@ -86105,7 +85909,7 @@
         "count": 1
       },
       {
-        "translation": "have much work (with G2480)",
+        "translation": "have much work",
         "count": 1
       }
     ],
@@ -86666,7 +86470,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "millstone (with G3037)",
+        "translation": "millstone",
         "count": 1
       }
     ],
@@ -86687,12 +86491,8 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "millstone (with G3684)",
-        "count": 2
-      },
-      {
         "translation": "millstone",
-        "count": 2
+        "count": 4
       }
     ],
     "outline_definitions": [
@@ -86760,7 +86560,7 @@
         "count": 2
       },
       {
-        "translation": "two hundred thousand thousand (with G1417)",
+        "translation": "two hundred thousand thousand",
         "count": 2
       },
       {
@@ -86776,7 +86576,7 @@
         "count": 1
       },
       {
-        "translation": "fifty thousand (with G3902)",
+        "translation": "fifty thousand",
         "count": 1
       },
       {
@@ -87387,7 +87187,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "spikenard (with G4101)",
+        "translation": "spikenard",
         "count": 2
       }
     ],
@@ -88672,7 +88472,7 @@
         "count": 1
       },
       {
-        "translation": "eat (with G2192)",
+        "translation": "eat",
         "count": 1
       }
     ],
@@ -89298,7 +89098,7 @@
         "count": 4
       },
       {
-        "translation": "this (with G3588)",
+        "translation": "this",
         "count": 3
       },
       {
@@ -89375,7 +89175,7 @@
         "count": 63
       },
       {
-        "translation": "midnight (with G3319)",
+        "translation": "midnight",
         "count": 2
       }
     ],
@@ -90803,11 +90603,11 @@
         "count": 3
       },
       {
-        "translation": "home (with G1519)",
+        "translation": "home",
         "count": 2
       },
       {
-        "translation": "at home (with G1722)",
+        "translation": "at home",
         "count": 2
       },
       {
@@ -90991,7 +90791,7 @@
         "count": 32
       },
       {
-        "translation": "winepress (with G3125)",
+        "translation": "winepress",
         "count": 1
       }
     ],
@@ -91172,7 +90972,7 @@
         "count": 6
       },
       {
-        "translation": "eighteen (with G1176) (with G2532)",
+        "translation": "eighteen",
         "count": 3
       }
     ],
@@ -91250,7 +91050,7 @@
         "count": 4
       },
       {
-        "translation": "almost (with G1722)",
+        "translation": "almost",
         "count": 2
       },
       {
@@ -91468,7 +91268,7 @@
         "count": 1
       },
       {
-        "translation": "throughout (with G1223)",
+        "translation": "throughout",
         "count": 1
       }
     ],
@@ -91803,7 +91603,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "like as (with G2596)",
+        "translation": "like as",
         "count": 1
       },
       {
@@ -91905,7 +91705,7 @@
         "count": 28
       },
       {
-        "translation": "moreover (with G1161)",
+        "translation": "moreover",
         "count": 1
       },
       {
@@ -92304,7 +92104,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "millstone (with G3458)",
+        "translation": "millstone",
         "count": 2
       }
     ],
@@ -92352,19 +92152,15 @@
       },
       {
         "translation": "named",
-        "count": 28
+        "count": 29
       },
       {
         "translation": "called",
         "count": 4
       },
       {
-        "translation": "surname (with G2007)",
+        "translation": "surname",
         "count": 2
-      },
-      {
-        "translation": "named (with G2564)",
-        "count": 1
       },
       {
         "translation": "not translated",
@@ -92590,19 +92386,15 @@
         "count": 6
       },
       {
-        "translation": "back (with G1519) (with G3588)",
-        "count": 5
-      },
-      {
         "translation": "back",
-        "count": 1
+        "count": 6
       },
       {
         "translation": "follow",
         "count": 1
       },
       {
-        "translation": "backward (with G1519) (with G3588)",
+        "translation": "backward",
         "count": 1
       }
     ],
@@ -92690,7 +92482,7 @@
         "count": 1
       },
       {
-        "translation": "whatsoever (with G4118)",
+        "translation": "whatsoever",
         "count": 1
       },
       {
@@ -92742,16 +92534,12 @@
         "count": 9
       },
       {
-        "translation": "wheresoever (with G302)",
-        "count": 3
+        "translation": "wheresoever",
+        "count": 5
       },
       {
-        "translation": "whithersoever (with G302)",
+        "translation": "whithersoever",
         "count": 4
-      },
-      {
-        "translation": "wheresoever (with G1437)",
-        "count": 2
       },
       {
         "translation": "whereas",
@@ -93398,14 +93186,14 @@
     "english_translations": [
       {
         "translation": "determine",
-        "count": 2
+        "count": 3
       },
       {
         "translation": "ordain",
         "count": 2
       },
       {
-        "translation": "as it was determined (with G2596) (with G3588)",
+        "translation": "as it was determined",
         "count": 1
       },
       {
@@ -93414,10 +93202,6 @@
       },
       {
         "translation": "limit",
-        "count": 1
-      },
-      {
-        "translation": "determine",
         "count": 1
       }
     ],
@@ -93822,15 +93606,11 @@
     "part_of_speech": "adverb",
     "english_translations": [
       {
-        "translation": "as often as (with G302)",
-        "count": 1
+        "translation": "as often as",
+        "count": 2
       },
       {
-        "translation": "as often as (with G1437)",
-        "count": 1
-      },
-      {
-        "translation": "as oft as (with G302)",
+        "translation": "as oft as",
         "count": 1
       }
     ],
@@ -94047,23 +93827,15 @@
       },
       {
         "translation": "whosoever",
-        "count": 12
+        "count": 15
       },
       {
         "translation": "that",
         "count": 8
       },
       {
-        "translation": "whatsoever (with G302)",
-        "count": 4
-      },
-      {
-        "translation": "whosoever (with G302)",
-        "count": 3
-      },
-      {
-        "translation": "whatsoever (with G3956) (with G302)",
-        "count": 2
+        "translation": "whatsoever",
+        "count": 6
       },
       {
         "translation": "miscellaneous",
@@ -94183,7 +93955,7 @@
         "count": 1
       },
       {
-        "translation": "till (with G1508)",
+        "translation": "till",
         "count": 1
       }
     ],
@@ -94317,7 +94089,7 @@
         "count": 147
       },
       {
-        "translation": "cannot (with G1410)",
+        "translation": "cannot",
         "count": 57
       },
       {
@@ -94364,7 +94136,7 @@
         "count": 1
       },
       {
-        "translation": "whithersoever (with G1437)",
+        "translation": "whithersoever",
         "count": 1
       }
     ],
@@ -94558,7 +94330,7 @@
         "count": 1
       },
       {
-        "translation": "nothing at any time (with G3856)",
+        "translation": "nothing at any time",
         "count": 1
       }
     ],
@@ -94825,7 +94597,7 @@
         "count": 5
       },
       {
-        "translation": "heavenly (with G1537)",
+        "translation": "heavenly",
         "count": 1
       }
     ],
@@ -95081,15 +94853,11 @@
     "english_translations": [
       {
         "translation": "not",
-        "count": 46
+        "count": 50
       },
       {
         "translation": "nay",
         "count": 5
-      },
-      {
-        "translation": "not",
-        "count": 4
       },
       {
         "translation": "not so",
@@ -95595,15 +95363,15 @@
         "count": 4
       },
       {
-        "translation": "in the evening (with G1096)",
+        "translation": "in the evening",
         "count": 1
       },
       {
-        "translation": "eventide (with G5610)",
+        "translation": "eventide",
         "count": 1
       },
       {
-        "translation": "at even (with G1096)",
+        "translation": "at even",
         "count": 1
       }
     ],
@@ -96691,7 +96459,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "in no wise (with G1519) (with G3588)",
+        "translation": "in no wise",
         "count": 1
       },
       {
@@ -96830,7 +96598,7 @@
         "count": 1
       },
       {
-        "translation": "must needs (with G1163)",
+        "translation": "must needs",
         "count": 1
       },
       {
@@ -97527,7 +97295,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "that ... committed (with G3588)",
+        "translation": "that ... committed",
         "count": 1
       }
     ],
@@ -97720,7 +97488,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "that committed to (one's) trust (with G3588)",
+        "translation": "that committed to (one's) trust",
         "count": 2
       }
     ],
@@ -98586,14 +98354,10 @@
     "english_translations": [
       {
         "translation": "watched",
-        "count": 4
+        "count": 5
       },
       {
         "translation": "observe",
-        "count": 1
-      },
-      {
-        "translation": "watched (with G2258)",
         "count": 1
       }
     ],
@@ -98732,10 +98496,6 @@
       {
         "translation": "remove",
         "count": 1
-      },
-      {
-        "translation": "variations of 'take away'",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -98915,11 +98675,11 @@
         "count": 1
       },
       {
-        "translation": "such things as one hath (with G3588)",
+        "translation": "such things as one hath",
         "count": 1
       },
       {
-        "translation": "he that lacketh (with G3361) (with G3739)",
+        "translation": "he that lacketh",
         "count": 1
       }
     ],
@@ -99239,7 +98999,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "trouble (with G2873)",
+        "translation": "trouble",
         "count": 5
       },
       {
@@ -99738,7 +99498,7 @@
         "count": 1
       },
       {
-        "translation": "to provoke unto (with G1519)",
+        "translation": "to provoke unto",
         "count": 1
       }
     ],
@@ -99882,18 +99642,14 @@
       },
       {
         "translation": "openly",
-        "count": 4
+        "count": 6
       },
       {
         "translation": "plainly",
         "count": 4
       },
       {
-        "translation": "openly (with G1722)",
-        "count": 2
-      },
-      {
-        "translation": "boldly (with G1722)",
+        "translation": "boldly",
         "count": 1
       },
       {
@@ -99982,7 +99738,7 @@
       },
       {
         "translation": "whosoever",
-        "count": 31
+        "count": 34
       },
       {
         "translation": "everyone",
@@ -100001,8 +99757,8 @@
         "count": 11
       },
       {
-        "translation": "no (with G3756)",
-        "count": 9
+        "translation": "no",
+        "count": 11
       },
       {
         "translation": "every thing",
@@ -100017,23 +99773,15 @@
         "count": 6
       },
       {
-        "translation": "whosoever (with G3739) (with G302)",
+        "translation": "always",
         "count": 3
       },
       {
-        "translation": "always (with G1223)",
-        "count": 3
-      },
-      {
-        "translation": "daily (with G2250)",
+        "translation": "daily",
         "count": 2
       },
       {
         "translation": "any thing",
-        "count": 2
-      },
-      {
-        "translation": "no (with G3361)",
         "count": 2
       },
       {
@@ -100100,7 +99848,7 @@
         "count": 1
       },
       {
-        "translation": "passion (with G3588)",
+        "translation": "passion",
         "count": 1
       },
       {
@@ -100581,7 +100329,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "plain (with G5117)",
+        "translation": "plain",
         "count": 1
       }
     ],
@@ -100788,7 +100536,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "assay (with G2983)",
+        "translation": "assay",
         "count": 1
       },
       {
@@ -101259,11 +101007,11 @@
         "count": 36
       },
       {
-        "translation": "three score and fifteen (with G1440)",
+        "translation": "three score and fifteen",
         "count": 1
       },
       {
-        "translation": "fifty thousand (with G3461)",
+        "translation": "fifty thousand",
         "count": 1
       }
     ],
@@ -101527,7 +101275,7 @@
         "count": 3
       },
       {
-        "translation": "whereof (with G3739)",
+        "translation": "whereof",
         "count": 3
       },
       {
@@ -101843,11 +101591,11 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "be astonished (with G2285)",
+        "translation": "be astonished",
         "count": 1
       },
       {
-        "translation": "after this manner (with G5126) (with G5176)",
+        "translation": "after this manner",
         "count": 1
       },
       {
@@ -102031,7 +101779,7 @@
         "count": 1
       },
       {
-        "translation": "be compassed about with (with G2192)",
+        "translation": "be compassed about with",
         "count": 1
       }
     ],
@@ -102439,7 +102187,7 @@
         "count": 1
       },
       {
-        "translation": "to obtain (with G1519)",
+        "translation": "to obtain",
         "count": 1
       },
       {
@@ -102451,7 +102199,7 @@
         "count": 1
       },
       {
-        "translation": "peculiar (with G1519)",
+        "translation": "peculiar",
         "count": 1
       }
     ],
@@ -102644,7 +102392,7 @@
         "count": 1
       },
       {
-        "translation": "vehemently (with G1537)",
+        "translation": "vehemently",
         "count": 1
       },
       {
@@ -102660,15 +102408,15 @@
         "count": 1
       },
       {
-        "translation": "very highly (with G5228) (with G1537)",
+        "translation": "very highly",
         "count": 1
       },
       {
-        "translation": "exceeding abundantly above (with G5228) (with G1537)",
+        "translation": "exceeding abundantly above",
         "count": 1
       },
       {
-        "translation": "exceeding (with G5228) (with G1537)",
+        "translation": "exceeding",
         "count": 1
       }
     ],
@@ -102918,7 +102666,7 @@
         "count": 1
       },
       {
-        "translation": "hedge around (with G5318)",
+        "translation": "hedge around",
         "count": 1
       }
     ],
@@ -102972,7 +102720,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "make mad (with G3130) (with G1519)",
+        "translation": "make mad",
         "count": 1
       }
     ],
@@ -103163,7 +102911,7 @@
     "part_of_speech": "adverb",
     "english_translations": [
       {
-        "translation": "a year ago (with G575)",
+        "translation": "a year ago",
         "count": 2
       }
     ],
@@ -103957,7 +103705,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "spikenard (with G3487)",
+        "translation": "spikenard",
         "count": 2
       }
     ],
@@ -103987,7 +103735,7 @@
         "count": 1
       },
       {
-        "translation": "believe (with G1537)",
+        "translation": "believe",
         "count": 1
       },
       {
@@ -104475,7 +104223,7 @@
         "count": 5
       },
       {
-        "translation": "further (with G1909)",
+        "translation": "further",
         "count": 3
       },
       {
@@ -106689,7 +106437,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "journeying (with G4160)",
+        "translation": "journeying",
         "count": 1
       },
       {
@@ -107286,7 +107034,7 @@
         "count": 12
       },
       {
-        "translation": "how long (with G2193)",
+        "translation": "how long",
         "count": 7
       }
     ],
@@ -107510,7 +107258,7 @@
         "count": 85
       },
       {
-        "translation": "footstool (with G5286)",
+        "translation": "footstool",
         "count": 8
       }
     ],
@@ -108209,7 +107957,7 @@
         "count": 2
       },
       {
-        "translation": "went before (with G2258)",
+        "translation": "went before",
         "count": 1
       },
       {
@@ -108360,7 +108108,7 @@
         "count": 1
       },
       {
-        "translation": "be of ... age (with G2250) (with G1722)",
+        "translation": "be of ... age",
         "count": 1
       }
     ],
@@ -108436,7 +108184,7 @@
         "count": 40
       },
       {
-        "translation": "sheepfold (with G833)",
+        "translation": "sheepfold",
         "count": 1
       }
     ],
@@ -109029,7 +108777,7 @@
         "count": 8
       },
       {
-        "translation": "shewbread (with G740)",
+        "translation": "shewbread",
         "count": 4
       }
     ],
@@ -110099,7 +109847,7 @@
         "count": 3
       },
       {
-        "translation": "waited for (with G2258)",
+        "translation": "waited for",
         "count": 1
       },
       {
@@ -110140,7 +109888,7 @@
         "count": 8
       },
       {
-        "translation": "waited for (with G2258)",
+        "translation": "waited for",
         "count": 2
       },
       {
@@ -110344,7 +110092,7 @@
         "count": 36
       },
       {
-        "translation": "prayed earnestly (with G4336)",
+        "translation": "prayed earnestly",
         "count": 1
       }
     ],
@@ -110421,7 +110169,7 @@
         "count": 1
       },
       {
-        "translation": "take heed whereunto (with G3739)",
+        "translation": "take heed whereunto",
         "count": 1
       },
       {
@@ -110728,7 +110476,7 @@
     "part_of_speech": "neuter noun",
     "english_translations": [
       {
-        "translation": "stumbling stone (with G3037)",
+        "translation": "stumbling stone",
         "count": 2
       },
       {
@@ -111268,7 +111016,7 @@
         "count": 11
       },
       {
-        "translation": "again send (with G3892)",
+        "translation": "again send",
         "count": 2
       },
       {
@@ -111740,8 +111488,8 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "before (with G3588)",
-        "count": 3
+        "translation": "before",
+        "count": 5
       },
       {
         "translation": "first",
@@ -111752,11 +111500,7 @@
         "count": 2
       },
       {
-        "translation": "before",
-        "count": 2
-      },
-      {
-        "translation": "at the first (with G3588)",
+        "translation": "at the first",
         "count": 1
       }
     ],
@@ -112411,7 +112155,7 @@
         "count": 52
       },
       {
-        "translation": "at the first (with G3588)",
+        "translation": "at the first",
         "count": 2
       },
       {
@@ -113381,29 +113125,6 @@
     ]
   },
   {
-    "concord_id": "G4452",
-    "original_word": "πώς",
-    "transliteration": "pōs",
-    "part_of_speech": "particle",
-    "english_translations": [
-      {
-        "translation": "none",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "yet, even",
-      "used only in compound with words 3369, 3380, 3764, 3768, 4455"
-    ],
-    "strongs_definition": [
-      "-πω -pō, po",
-      "another form of the base of G4458",
-      "an enclitic particle of indefiniteness",
-      "yet, even",
-      "used only in the comparative. See G3369, G3380, G3764, G3768, G4455."
-    ]
-  },
-  {
     "concord_id": "G4453",
     "original_word": "πωλέω",
     "transliteration": "pōleō",
@@ -113462,16 +113183,12 @@
         "count": 3
       },
       {
-        "translation": "yet never (with G3762)",
+        "translation": "yet never",
         "count": 1
       },
       {
         "translation": "never",
-        "count": 1
-      },
-      {
-        "translation": "never (with G3364)",
-        "count": 1
+        "count": 2
       }
     ],
     "outline_definitions": [
@@ -113966,15 +113683,11 @@
     "part_of_speech": "neuter noun",
     "english_translations": [
       {
-        "translation": "strike with the palm of (one's) hand (with G906)",
-        "count": 1
+        "translation": "strike with the palm of (one's) hand",
+        "count": 2
       },
       {
-        "translation": "strike with the palm of (one's) hand (with G1325)",
-        "count": 1
-      },
-      {
-        "translation": "smite with (one's) hand (with G1325)",
+        "translation": "smite with (one's) hand",
         "count": 1
       }
     ],
@@ -114146,11 +113859,7 @@
         "count": 12
       },
       {
-        "translation": "say",
-        "count": null
-      },
-      {
-        "translation": "speak of",
+        "translation": "say, speak of",
         "count": 3
       },
       {
@@ -114285,7 +113994,7 @@
         "count": 3
       },
       {
-        "translation": "no thing (with G3756)",
+        "translation": "no thing",
         "count": 1
       },
       {
@@ -115307,7 +115016,7 @@
         "count": 1
       },
       {
-        "translation": "which cannot be shaken (with G3361)",
+        "translation": "which cannot be shaken",
         "count": 1
       },
       {
@@ -115979,7 +115688,7 @@
         "count": 2
       },
       {
-        "translation": "carnally minded (with G5427)",
+        "translation": "carnally minded",
         "count": 1
       },
       {
@@ -116801,7 +116510,7 @@
         "count": 18
       },
       {
-        "translation": "this (with G3588)",
+        "translation": "this",
         "count": 1
       }
     ],
@@ -119363,7 +119072,7 @@
         "count": 1
       },
       {
-        "translation": "tender mercy (with G1656)",
+        "translation": "tender mercy",
         "count": 1
       }
     ],
@@ -120657,7 +120366,7 @@
         "count": 1
       },
       {
-        "translation": "them (with G848)",
+        "translation": "them",
         "count": 1
       },
       {
@@ -121312,7 +121021,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "sat (with G2258)",
+        "translation": "sat",
         "count": 1
       },
       {
@@ -121506,7 +121215,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "consented (with G2258)",
+        "translation": "consented",
         "count": 1
       }
     ],
@@ -121688,12 +121397,8 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "partaker with (with G1096)",
-        "count": 1
-      },
-      {
         "translation": "partaker with",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "partaker",
@@ -123477,7 +123182,7 @@
         "count": 1
       },
       {
-        "translation": "accompany (with G2064)",
+        "translation": "accompany",
         "count": 1
       }
     ],
@@ -123664,11 +123369,7 @@
       },
       {
         "translation": "reckon",
-        "count": 1
-      },
-      {
-        "translation": "reckon (with G3056)",
-        "count": 1
+        "count": 2
       }
     ],
     "outline_definitions": [
@@ -123887,7 +123588,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "to meet (with G1519)",
+        "translation": "to meet",
         "count": 1
       }
     ],
@@ -124190,7 +123891,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "run together (with G1096)",
+        "translation": "run together",
         "count": 1
       }
     ],
@@ -124426,7 +124127,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "set at one again (with G1515) (with G1519)",
+        "translation": "set at one again",
         "count": 1
       }
     ],
@@ -124574,7 +124275,7 @@
       },
       {
         "translation": "come with",
-        "count": 2
+        "count": 3
       },
       {
         "translation": "resort",
@@ -124583,10 +124284,6 @@
       {
         "translation": "come",
         "count": 2
-      },
-      {
-        "translation": "come with (with G2258)",
-        "count": 1
       },
       {
         "translation": "company with",
@@ -125176,7 +124873,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "join hard (with G2258)",
+        "translation": "join hard",
         "count": 1
       }
     ],
@@ -125462,7 +125159,7 @@
         "count": 1
       },
       {
-        "translation": "brokenhearted (with G2588)",
+        "translation": "brokenhearted",
         "count": 1
       },
       {
@@ -126780,7 +126477,7 @@
         "count": 1
       },
       {
-        "translation": "deliver (with G1325)",
+        "translation": "deliver",
         "count": 1
       },
       {
@@ -126792,7 +126489,7 @@
         "count": 1
       },
       {
-        "translation": "that (one) be saved (with G1519)",
+        "translation": "that (one) be saved",
         "count": 1
       }
     ],
@@ -127660,7 +127357,7 @@
         "count": 6
       },
       {
-        "translation": "afterwards (with G3326)",
+        "translation": "afterwards",
         "count": 4
       },
       {
@@ -127784,7 +127481,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "to bury (with G1519)",
+        "translation": "to bury",
         "count": 1
       }
     ],
@@ -127922,7 +127619,7 @@
         "count": 1
       },
       {
-        "translation": "outrun (with G4390)",
+        "translation": "outrun",
         "count": 1
       },
       {
@@ -127946,7 +127643,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "with all speed (with G5613)",
+        "translation": "with all speed",
         "count": 1
       }
     ],
@@ -127966,15 +127663,15 @@
     "part_of_speech": "neuter noun",
     "english_translations": [
       {
-        "translation": "shortly (with G1722)",
+        "translation": "shortly",
         "count": 4
       },
       {
-        "translation": "quickly (with G1722)",
+        "translation": "quickly",
         "count": 2
       },
       {
-        "translation": "speedily (with G1722)",
+        "translation": "speedily",
         "count": 1
       }
     ],
@@ -128592,7 +128289,7 @@
         "count": 1
       },
       {
-        "translation": "by (one's) continual (with G1519)",
+        "translation": "by (one's) continual",
         "count": 1
       }
     ],
@@ -129341,7 +129038,7 @@
         "count": 6
       },
       {
-        "translation": "kneel down (with G1119) (with G3588)",
+        "translation": "kneel down",
         "count": 5
       },
       {
@@ -129679,7 +129376,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "be punished (with G1349)",
+        "translation": "be punished",
         "count": 1
       }
     ],
@@ -129756,7 +129453,7 @@
         "count": 2
       },
       {
-        "translation": "nothing (with G3756)",
+        "translation": "nothing",
         "count": 2
       },
       {
@@ -129874,27 +129571,6 @@
       "†Τίτος Títos, tee'-tos",
       "of Latin origin but uncertain significance",
       "Titus, a Christian:—Titus."
-    ]
-  },
-  {
-    "concord_id": "G5104",
-    "original_word": "τοι",
-    "transliteration": "toi",
-    "part_of_speech": "particle",
-    "english_translations": [
-      {
-        "translation": "none",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "certainly, truly"
-    ],
-    "strongs_definition": [
-      "τοί toí, toy",
-      "probably for the dative case of G3588",
-      "an enclitic particle of asseveration by way of contrast",
-      "in sooth:—(used only with other particles in the comparative, as G2544, G3305, G5105, G5106, etc. )"
     ]
   },
   {
@@ -130223,11 +129899,11 @@
         "count": 1
       },
       {
-        "translation": "plain (with G3977)",
+        "translation": "plain",
         "count": 1
       },
       {
-        "translation": "rock (with G5138)",
+        "translation": "rock",
         "count": 1
       }
     ],
@@ -130423,7 +130099,7 @@
         "count": 199
       },
       {
-        "translation": "therefore (with G1223)",
+        "translation": "therefore",
         "count": 44
       },
       {
@@ -130431,11 +130107,11 @@
         "count": 22
       },
       {
-        "translation": "for this cause (with G1223)",
+        "translation": "for this cause",
         "count": 14
       },
       {
-        "translation": "wherefore (with G1223)",
+        "translation": "wherefore",
         "count": 7
       },
       {
@@ -130492,14 +130168,10 @@
       },
       {
         "translation": "therewith",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "those",
-        "count": 1
-      },
-      {
-        "translation": "therewith (with G1909)",
         "count": 1
       },
       {
@@ -130575,7 +130247,7 @@
         "count": 1
       },
       {
-        "translation": "thereabout (with G4012)",
+        "translation": "thereabout",
         "count": 1
       },
       {
@@ -130651,11 +130323,11 @@
         "count": 10
       },
       {
-        "translation": "hereby (with G1722)",
+        "translation": "hereby",
         "count": 8
       },
       {
-        "translation": "herein (with G1722)",
+        "translation": "herein",
         "count": 7
       },
       {
@@ -130893,7 +130565,7 @@
         "count": 1
       },
       {
-        "translation": "rock (with G5117)",
+        "translation": "rock",
         "count": 1
       }
     ],
@@ -131306,7 +130978,7 @@
         "count": 4
       },
       {
-        "translation": "tremble (with G2192)",
+        "translation": "tremble",
         "count": 1
       }
     ],
@@ -131348,12 +131020,12 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "as (with G3739)",
+        "translation": "as",
         "count": 3
       },
       {
-        "translation": "even as (with G2596) (with G3739)",
-        "count": 2
+        "translation": "even as",
+        "count": 3
       },
       {
         "translation": "way",
@@ -131364,11 +131036,7 @@
         "count": 2
       },
       {
-        "translation": "even as (with G3739)",
-        "count": 1
-      },
-      {
-        "translation": "in like manner as (with G3639)",
+        "translation": "in like manner as",
         "count": 1
       },
       {
@@ -132617,11 +132285,11 @@
         "count": 85
       },
       {
-        "translation": "Son of Man (with G444)",
+        "translation": "Son of Man",
         "count": 87
       },
       {
-        "translation": "Son of God (with G2316)",
+        "translation": "Son of God",
         "count": 49
       },
       {
@@ -132633,31 +132301,31 @@
         "count": 42
       },
       {
-        "translation": "his Son (with G848)",
+        "translation": "his Son",
         "count": 21
       },
       {
-        "translation": "Son of David (with G1138)",
+        "translation": "Son of David",
         "count": 15
       },
       {
-        "translation": "my beloved Son (with G27) (with G3350)",
+        "translation": "my beloved Son",
         "count": 7
       },
       {
-        "translation": "thy Son (with G4575)",
+        "translation": "thy Son",
         "count": 5
       },
       {
-        "translation": "only begotten Son (with G3339)",
+        "translation": "only begotten Son",
         "count": 3
       },
       {
-        "translation": "his (David's) son (with G846)",
+        "translation": "his (David's) son",
         "count": 3
       },
       {
-        "translation": "firstborn son (with G4316)",
+        "translation": "firstborn son",
         "count": 2
       },
       {
@@ -132730,7 +132398,7 @@
         "count": 42
       },
       {
-        "translation": "for your sakes (with G1223)",
+        "translation": "for your sakes",
         "count": 9
       },
       {
@@ -133019,11 +132687,11 @@
         "count": 1
       },
       {
-        "translation": "to make obedient (with G1519)",
+        "translation": "to make obedient",
         "count": 1
       },
       {
-        "translation": "to obey (with G1519)",
+        "translation": "to obey",
         "count": 1
       },
       {
@@ -133126,7 +132794,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "to meet (with G1519)",
+        "translation": "to meet",
         "count": 1
       }
     ],
@@ -133321,7 +132989,7 @@
         "count": 2
       },
       {
-        "translation": "very chiefest (with G3029)",
+        "translation": "very chiefest",
         "count": 2
       },
       {
@@ -133341,15 +133009,15 @@
         "count": 1
       },
       {
-        "translation": "exceedingly abundantly (with G1537) (with G4053)",
+        "translation": "exceedingly abundantly",
         "count": 1
       },
       {
-        "translation": "exceedingly (with G1537) (with G4053)",
+        "translation": "exceedingly",
         "count": 1
       },
       {
-        "translation": "very highly (with G1537) (with G4053)",
+        "translation": "very highly",
         "count": 1
       },
       {
@@ -133402,7 +133070,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "pass the flower of (one's) age (with G5600)",
+        "translation": "pass the flower of (one's) age",
         "count": 1
       }
     ],
@@ -133548,23 +133216,23 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "far more (with G2596)",
+        "translation": "far more",
         "count": 1
       },
       {
-        "translation": "exceeding (with G2596)",
+        "translation": "exceeding",
+        "count": 2
+      },
+      {
+        "translation": "more excellent",
         "count": 1
       },
       {
-        "translation": "more excellent (with G2596)",
+        "translation": "out of measure",
         "count": 1
       },
       {
-        "translation": "out of measure (with G2596)",
-        "count": 1
-      },
-      {
-        "translation": "beyond measure (with G2596)",
+        "translation": "beyond measure",
         "count": 1
       },
       {
@@ -133573,10 +133241,6 @@
       },
       {
         "translation": "abundance",
-        "count": 1
-      },
-      {
-        "translation": "exceeding (with G1519)",
         "count": 1
       }
     ],
@@ -134012,7 +133676,7 @@
         "count": 2
       },
       {
-        "translation": "obey (with G1096)",
+        "translation": "obey",
         "count": 1
       }
     ],
@@ -134826,12 +134490,8 @@
     "part_of_speech": "neuter noun",
     "english_translations": [
       {
-        "translation": "footstool (with G4228)",
-        "count": 8
-      },
-      {
         "translation": "footstool",
-        "count": 1
+        "count": 9
       }
     ],
     "outline_definitions": [
@@ -135185,7 +134845,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "withdrew (with G2258)",
+        "translation": "withdrew",
         "count": 1
       },
       {
@@ -135761,7 +135421,7 @@
         "count": 9
       },
       {
-        "translation": "openly (with G1722) (with G3588)",
+        "translation": "openly",
         "count": 3
       },
       {
@@ -135769,7 +135429,7 @@
         "count": 3
       },
       {
-        "translation": "abroad (with G1519)",
+        "translation": "abroad",
         "count": 2
       },
       {
@@ -135777,7 +135437,7 @@
         "count": 1
       },
       {
-        "translation": "outwardly (with G1722) (with G3588)",
+        "translation": "outwardly",
         "count": 1
       },
       {
@@ -136739,7 +136399,7 @@
         "count": 7
       },
       {
-        "translation": "to perish (with G1519)",
+        "translation": "to perish",
         "count": 1
       },
       {
@@ -137988,7 +137648,7 @@
         "count": 1
       },
       {
-        "translation": "be slain (with G599)",
+        "translation": "be slain",
         "count": 1
       }
     ],
@@ -138213,7 +137873,7 @@
         "count": 2
       },
       {
-        "translation": "hedge around about (with G4060)",
+        "translation": "hedge around about",
         "count": 1
       },
       {
@@ -138411,11 +138071,11 @@
         "count": 2
       },
       {
-        "translation": "be of the same mind (with G846)",
+        "translation": "be of the same mind",
         "count": 2
       },
       {
-        "translation": "be like minded (with G846)",
+        "translation": "be like minded",
         "count": 2
       },
       {
@@ -138452,11 +138112,11 @@
         "count": 2
       },
       {
-        "translation": "carnally minded (with G4561)",
+        "translation": "carnally minded",
         "count": 1
       },
       {
-        "translation": "spiritually minded (with G4151)",
+        "translation": "spiritually minded",
         "count": 1
       }
     ],
@@ -139007,7 +138667,7 @@
         "count": 10
       },
       {
-        "translation": "natural (with G2596)",
+        "translation": "natural",
         "count": 2
       },
       {
@@ -139015,7 +138675,7 @@
         "count": 1
       },
       {
-        "translation": "mankind (with G442)",
+        "translation": "mankind",
         "count": 1
       }
     ],
@@ -139205,7 +138865,7 @@
         "count": 8
       },
       {
-        "translation": "be noised abroad (with G1096)",
+        "translation": "be noised abroad",
         "count": 1
       },
       {
@@ -139826,7 +139486,7 @@
         "count": 1
       },
       {
-        "translation": "joyfully (with G3326)",
+        "translation": "joyfully",
         "count": 1
       },
       {
@@ -139973,7 +139633,7 @@
     "part_of_speech": "preposition",
     "english_translations": [
       {
-        "translation": "for this cause (with G5127)",
+        "translation": "for this cause",
         "count": 3
       },
       {
@@ -139981,7 +139641,7 @@
         "count": 2
       },
       {
-        "translation": "wherefore (with G3739)",
+        "translation": "wherefore",
         "count": 1
       },
       {
@@ -139993,7 +139653,7 @@
         "count": 1
       },
       {
-        "translation": "to speak reproachfully (with G3059)",
+        "translation": "to speak reproachfully",
         "count": 1
       }
     ],
@@ -140028,11 +139688,7 @@
       },
       {
         "translation": "thank",
-        "count": 4
-      },
-      {
-        "translation": "thank (with G2192)",
-        "count": 3
+        "count": 7
       },
       {
         "translation": "pleasure",
@@ -140430,22 +140086,18 @@
     "english_translations": [
       {
         "translation": "worse",
-        "count": 7
+        "count": 8
       },
       {
         "translation": "sorer",
         "count": 1
       },
       {
-        "translation": "worse (with G1519) (with G3588)",
+        "translation": "worse and worse",
         "count": 1
       },
       {
-        "translation": "worse and worse (with G1909) (with G3588)",
-        "count": 1
-      },
-      {
-        "translation": "a worse thing (with G5100)",
+        "translation": "a worse thing",
         "count": 1
       }
     ],
@@ -141151,11 +140803,7 @@
     "english_translations": [
       {
         "translation": "need",
-        "count": 25
-      },
-      {
-        "translation": "need (with G2192)",
-        "count": 14
+        "count": 39
       },
       {
         "translation": "necessity",
@@ -141657,7 +141305,7 @@
         "count": 2
       },
       {
-        "translation": "oftentimes (with G4183)",
+        "translation": "oftentimes",
         "count": 1
       },
       {
@@ -141976,7 +141624,7 @@
         "count": 1
       },
       {
-        "translation": "cannot receive (with G3756)",
+        "translation": "cannot receive",
         "count": 1
       },
       {
@@ -142666,7 +142314,7 @@
         "count": 1
       },
       {
-        "translation": "heartily (with G1537)",
+        "translation": "heartily",
         "count": 1
       },
       {
@@ -143608,7 +143256,7 @@
         "count": 3
       },
       {
-        "translation": "profit (with G2076)",
+        "translation": "profit",
         "count": 1
       }
     ],
@@ -143644,11 +143292,11 @@
         "count": 1
       },
       {
-        "translation": "fatherless (with H369)",
+        "translation": "fatherless",
         "count": 1
       },
       {
-        "translation": "forefathers (with H7223)",
+        "translation": "forefathers",
         "count": 1
       },
       {
@@ -145323,27 +144971,19 @@
         "count": 7
       },
       {
-        "translation": "divers weights (with H68)",
+        "translation": "divers weights",
         "count": 3
       },
       {
         "translation": "hailstones",
-        "count": 3
+        "count": 5
       },
       {
         "translation": "stony",
         "count": 2
       },
       {
-        "translation": "carbuncle (with H688)",
-        "count": 1
-      },
-      {
-        "translation": "hailstones (with H1259)",
-        "count": 1
-      },
-      {
-        "translation": "hailstones (with H417)",
+        "translation": "carbuncle",
         "count": 1
       },
       {
@@ -145351,7 +144991,7 @@
         "count": 1
       },
       {
-        "translation": "masons (with H7023)",
+        "translation": "masons",
         "count": 1
       },
       {
@@ -146689,7 +146329,7 @@
         "count": 8
       },
       {
-        "translation": "common sort (with H7230)",
+        "translation": "common sort",
         "count": 1
       },
       {
@@ -148579,43 +148219,6 @@
     ]
   },
   {
-    "concord_id": "H0194",
-    "original_word": "אוּלַי",
-    "transliteration": "'ûlay",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "if (so be)",
-        "count": null
-      },
-      {
-        "translation": "may (be)",
-        "count": null
-      },
-      {
-        "translation": "peradventure",
-        "count": null
-      },
-      {
-        "translation": "unless",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "perhaps, peradventure",
-      "if peradventure",
-      "unless",
-      "suppose"
-    ],
-    "strongs_definition": [
-      "אוּלַי ʼûwlay, oo-lah'ee",
-      "or (shortened) אֻלַי ʼulay",
-      "from H176",
-      "if not",
-      "hence perhaps:—if so be, may be, peradventure, unless."
-    ]
-  },
-  {
     "concord_id": "H0195",
     "original_word": "אוּלַי",
     "transliteration": "'ûlay",
@@ -149609,78 +149212,6 @@
     ]
   },
   {
-    "concord_id": "H0227",
-    "original_word": "אָז",
-    "transliteration": "'āz",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "beginning",
-        "count": null
-      },
-      {
-        "translation": "even",
-        "count": null
-      },
-      {
-        "translation": "for",
-        "count": null
-      },
-      {
-        "translation": "from",
-        "count": null
-      },
-      {
-        "translation": "hitherto",
-        "count": null
-      },
-      {
-        "translation": "now",
-        "count": null
-      },
-      {
-        "translation": "old",
-        "count": null
-      },
-      {
-        "translation": "since",
-        "count": null
-      },
-      {
-        "translation": "then",
-        "count": null
-      },
-      {
-        "translation": "time",
-        "count": null
-      },
-      {
-        "translation": "when",
-        "count": null
-      },
-      {
-        "translation": "yet",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "then, at that time",
-      "temporal expressions",
-      "then (past)",
-      "then, if...then (future)",
-      "earlier",
-      "logical expressions",
-      "in that case",
-      "that (being so)"
-    ],
-    "strongs_definition": [
-      "אָז ʼâz, awz",
-      "a demonstrative adverb",
-      "at that time or place",
-      "also as a conjunction, therefore:—beginning, for, from, hitherto, now, of old, once, since, then, at which time, yet."
-    ]
-  },
-  {
     "concord_id": "H0228",
     "original_word": "אֲזָא",
     "transliteration": "'ăzā'",
@@ -150017,11 +149548,11 @@
         "count": 5
       },
       {
-        "translation": "show (with H1540)",
+        "translation": "show",
         "count": 6
       },
       {
-        "translation": "advertise (with H1540)",
+        "translation": "advertise",
         "count": 1
       },
       {
@@ -150030,18 +149561,14 @@
       },
       {
         "translation": "hear",
+        "count": 2
+      },
+      {
+        "translation": "reveal",
         "count": 1
       },
       {
-        "translation": "hear (with H8088)",
-        "count": 1
-      },
-      {
-        "translation": "reveal (with H1540)",
-        "count": 1
-      },
-      {
-        "translation": "tell (with H1540)",
+        "translation": "tell",
         "count": 1
       }
     ],
@@ -150301,7 +149828,7 @@
       },
       {
         "translation": "another",
-        "count": 23
+        "count": 24
       },
       {
         "translation": "brotherly",
@@ -150313,10 +149840,6 @@
       },
       {
         "translation": "like",
-        "count": 1
-      },
-      {
-        "translation": "another",
         "count": 1
       },
       {
@@ -150521,7 +150044,7 @@
         "count": 13
       },
       {
-        "translation": "eleven (with H6240)",
+        "translation": "eleven",
         "count": 13
       },
       {
@@ -150811,7 +150334,7 @@
         "count": 6
       },
       {
-        "translation": "together with (with H802)",
+        "translation": "together with",
         "count": 1
       },
       {
@@ -151036,31 +150559,6 @@
       "from H251",
       "brotherly",
       "Achi, the name of two Israelites:—Ahi."
-    ]
-  },
-  {
-    "concord_id": "H0278",
-    "original_word": "אֵחִי",
-    "transliteration": "'ēḥî",
-    "part_of_speech": "proper masculine noun",
-    "english_translations": [
-      {
-        "translation": "Ehi",
-        "count": null
-      },
-      {
-        "translation": "1",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "Ehi = \"my brother\"",
-      "son of Benjamin"
-    ],
-    "strongs_definition": [
-      "אֵחִי ʼÊchîy, ay-khee'",
-      "probably the same as H277",
-      "Echi, an Israelite:—Ehi."
     ]
   },
   {
@@ -152486,7 +151984,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "lefthanded (with H3025)",
+        "translation": "lefthanded",
         "count": 2
       }
     ],
@@ -152497,35 +151995,6 @@
       "אִטֵּר ʼiṭṭêr, it-tare'",
       "from H332",
       "shut up, i.e. impeded (as to the use of the right hand):— left-handed."
-    ]
-  },
-  {
-    "concord_id": "H0335",
-    "original_word": "אַי",
-    "transliteration": "'ay",
-    "part_of_speech": "interrogative adverb",
-    "english_translations": [
-      {
-        "translation": "where",
-        "count": null
-      },
-      {
-        "translation": "what",
-        "count": null
-      },
-      {
-        "translation": "whence",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "where?, whence?",
-      "which?, how? (in prefix with other adverb)"
-    ],
-    "strongs_definition": [
-      "אַי ʼay, ah'ee",
-      "perhaps from H370",
-      "where? hence how?:—how, what, whence, where, whether, which (way)."
     ]
   },
   {
@@ -152835,39 +152304,6 @@
       "אִיזֶבֶל ʼÎyzebel, ee-zeh'-bel",
       "from H336 and H2083",
       "Izebel, the wife of king Ahab:—Jezebel."
-    ]
-  },
-  {
-    "concord_id": "H0349",
-    "original_word": "אֵיךְ",
-    "transliteration": "'êḵ",
-    "part_of_speech": "interjection, interrogative adverb",
-    "english_translations": [
-      {
-        "translation": "how",
-        "count": null
-      },
-      {
-        "translation": "what",
-        "count": null
-      },
-      {
-        "translation": "where",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "how?",
-      "how! (in lamentation)",
-      "expression of satisfaction"
-    ],
-    "strongs_definition": [
-      "אֵיךְ ʼêyk, ake",
-      "also אֵיכָה ʼêykâh",
-      "and אֵיכָכָה ʼêykâkâh",
-      "prolonged from H335",
-      "how? or how!",
-      "also where:—how, what."
     ]
   },
   {
@@ -153341,84 +152777,6 @@
       "plural of H367",
       "terrors",
       "Emim, an early Canaanitish (or Maobitish) tribe:—Emims."
-    ]
-  },
-  {
-    "concord_id": "H0369",
-    "original_word": "אִין",
-    "transliteration": "'în",
-    "part_of_speech": "adverb, noun, negation",
-    "english_translations": [
-      {
-        "translation": "except",
-        "count": null
-      },
-      {
-        "translation": "faileth",
-        "count": null
-      },
-      {
-        "translation": "fatherless",
-        "count": null
-      },
-      {
-        "translation": "incurable",
-        "count": null
-      },
-      {
-        "translation": "infinite",
-        "count": null
-      },
-      {
-        "translation": "innumerable",
-        "count": null
-      },
-      {
-        "translation": "neither",
-        "count": null
-      },
-      {
-        "translation": "never",
-        "count": null
-      },
-      {
-        "translation": "no",
-        "count": null
-      },
-      {
-        "translation": "none",
-        "count": null
-      },
-      {
-        "translation": "not",
-        "count": null
-      },
-      {
-        "translation": "nothing",
-        "count": null
-      },
-      {
-        "translation": "nought",
-        "count": null
-      },
-      {
-        "translation": "without",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "nothing, not, nought",
-      "nothing, nought",
-      "not",
-      "to have not (of possession)",
-      "without",
-      "for lack of"
-    ],
-    "strongs_definition": [
-      "אַיִן ʼayin, ah'-yin",
-      "as if from a primitive root meaning to be nothing or not exist",
-      "a nonentity",
-      "generally used as a negative particle:—else, except, fail, (father-) less, be gone, in(-curable), neither, never, no (where), none, nor, (any, thing), not, nothing, to nought, past, un(-searchable), well-nigh, without. Compare H370."
     ]
   },
   {
@@ -153911,92 +153269,6 @@
     ]
   },
   {
-    "concord_id": "H0389",
-    "original_word": "אַךְ",
-    "transliteration": "'aḵ",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "also",
-        "count": null
-      },
-      {
-        "translation": "but",
-        "count": null
-      },
-      {
-        "translation": "certainly",
-        "count": null
-      },
-      {
-        "translation": "even",
-        "count": null
-      },
-      {
-        "translation": "howbeit",
-        "count": null
-      },
-      {
-        "translation": "least",
-        "count": null
-      },
-      {
-        "translation": "nevertheless",
-        "count": null
-      },
-      {
-        "translation": "notwithstanding",
-        "count": null
-      },
-      {
-        "translation": "only",
-        "count": null
-      },
-      {
-        "translation": "save",
-        "count": null
-      },
-      {
-        "translation": "scarce",
-        "count": null
-      },
-      {
-        "translation": "surely",
-        "count": null
-      },
-      {
-        "translation": "surety",
-        "count": null
-      },
-      {
-        "translation": "truly",
-        "count": null
-      },
-      {
-        "translation": "verily",
-        "count": null
-      },
-      {
-        "translation": "wherefore",
-        "count": null
-      },
-      {
-        "translation": "yet",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "indeed, surely (emphatic)",
-      "howbeit, only, but, yet (restrictive)"
-    ],
-    "strongs_definition": [
-      "אַךְ ʼak, ak",
-      "akin to H403",
-      "a particle of affirmation, surely",
-      "hence (by limitation) only:—also, in any wise, at least, but, certainly, even, howbeit, nevertheless, notwithstanding, only, save, surely, of a surety, truly, verily, wherefore, yet (but)."
-    ]
-  },
-  {
     "concord_id": "H0390",
     "original_word": "אַכַּד",
     "transliteration": "'akaḏ",
@@ -154286,7 +153558,7 @@
         "count": 2
       },
       {
-        "translation": "mealtime (with H6256)",
+        "translation": "mealtime",
         "count": 1
       }
     ],
@@ -154625,7 +153897,7 @@
         "count": 1
       },
       {
-        "translation": "Immanuel (with H6005)",
+        "translation": "Immanuel",
         "count": 2
       },
       {
@@ -154694,113 +153966,6 @@
     "strongs_definition": [
       "אֵל ʼêl, ale",
       "(Aramaic) corresponding to H411:—these."
-    ]
-  },
-  {
-    "concord_id": "H0413",
-    "original_word": "אֵל",
-    "transliteration": "'ēl",
-    "part_of_speech": "preposition",
-    "english_translations": [
-      {
-        "translation": "unto",
-        "count": null
-      },
-      {
-        "translation": "with",
-        "count": null
-      },
-      {
-        "translation": "against",
-        "count": null
-      },
-      {
-        "translation": "at",
-        "count": null
-      },
-      {
-        "translation": "into",
-        "count": null
-      },
-      {
-        "translation": "in",
-        "count": null
-      },
-      {
-        "translation": "before",
-        "count": null
-      },
-      {
-        "translation": "to",
-        "count": null
-      },
-      {
-        "translation": "of",
-        "count": null
-      },
-      {
-        "translation": "upon",
-        "count": null
-      },
-      {
-        "translation": "by",
-        "count": null
-      },
-      {
-        "translation": "toward",
-        "count": null
-      },
-      {
-        "translation": "hath",
-        "count": null
-      },
-      {
-        "translation": "for",
-        "count": null
-      },
-      {
-        "translation": "on",
-        "count": null
-      },
-      {
-        "translation": "beside",
-        "count": null
-      },
-      {
-        "translation": "from",
-        "count": null
-      },
-      {
-        "translation": "where",
-        "count": null
-      },
-      {
-        "translation": "after",
-        "count": null
-      },
-      {
-        "translation": "within",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "to, toward, unto (of motion)",
-      "into (limit is actually entered)",
-      "in among",
-      "toward (of direction, not necessarily physical motion)",
-      "against (motion or direction of a hostile character)",
-      "in addition to, to",
-      "concerning, in regard to, in reference to, on account of",
-      "according to (rule or standard)",
-      "at, by, against (of one's presence)",
-      "in between, in within, to within, unto (idea of motion to)"
-    ],
-    "strongs_definition": [
-      "אֵל ʼêl, ale",
-      "(but used only in the shortened constructive form אֶל ʼel, el)",
-      "a primitive particle",
-      "properly, denoting motion towards, but occasionally used of a quiescent position, i.e. near, with or among",
-      "often in general, to:—about, according to, after, against, among, as for, at, because (-fore, -side), both...and, by, concerning, for, from, × hath, in (-to), near, (out) of, over, through, to (-ward), under, unto, upon, whether, with (-in)."
     ]
   },
   {
@@ -154876,7 +154041,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "hailstone (with H68)",
+        "translation": "hailstone",
         "count": 3
       }
     ],
@@ -155149,85 +154314,6 @@
     ]
   },
   {
-    "concord_id": "H0428",
-    "original_word": "אֵלֶּה",
-    "transliteration": "'ēllê",
-    "part_of_speech": "demonstrative particle",
-    "english_translations": [
-      {
-        "translation": "these",
-        "count": null
-      },
-      {
-        "translation": "those",
-        "count": null
-      },
-      {
-        "translation": "this",
-        "count": null
-      },
-      {
-        "translation": "thus",
-        "count": null
-      },
-      {
-        "translation": "who",
-        "count": null
-      },
-      {
-        "translation": "so",
-        "count": null
-      },
-      {
-        "translation": "such",
-        "count": null
-      },
-      {
-        "translation": "some",
-        "count": null
-      },
-      {
-        "translation": "same",
-        "count": null
-      },
-      {
-        "translation": "other",
-        "count": null
-      },
-      {
-        "translation": "which",
-        "count": null
-      },
-      {
-        "translation": "another",
-        "count": null
-      },
-      {
-        "translation": "whom",
-        "count": null
-      },
-      {
-        "translation": "they",
-        "count": null
-      },
-      {
-        "translation": "them",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "these",
-      "used before antecedent",
-      "used following antecedent"
-    ],
-    "strongs_definition": [
-      "אֵלֶּה ʼêl-leh, ale'-leh",
-      "prolonged from H411",
-      "these or those:—an-(the) other",
-      "one sort, so, some, such, them, these (same), they, this, those, thus, which, who(-m)."
-    ]
-  },
-  {
     "concord_id": "H0429",
     "original_word": "אֵלֶּה",
     "transliteration": "'ēllê",
@@ -155289,7 +154375,7 @@
         "count": 1
       },
       {
-        "translation": "God-ward (with H4136)",
+        "translation": "God-ward",
         "count": 1
       },
       {
@@ -157119,7 +156205,7 @@
         "count": 500
       },
       {
-        "translation": "eleven hundred (with H3967)",
+        "translation": "eleven hundred",
         "count": 3
       },
       {
@@ -157127,7 +156213,7 @@
         "count": 1
       },
       {
-        "translation": "twelve hundred (with H3967)",
+        "translation": "twelve hundred",
         "count": 1
       }
     ],
@@ -157414,80 +156500,6 @@
       "a primitive word",
       "a mother (as the bond of the family)",
       "in a wide sense (both literally and figuratively [like father]):—dam, mother, × parting."
-    ]
-  },
-  {
-    "concord_id": "H0518",
-    "original_word": "אִם",
-    "transliteration": "'im",
-    "part_of_speech": "particle",
-    "english_translations": [
-      {
-        "translation": "if",
-        "count": null
-      },
-      {
-        "translation": "not",
-        "count": null
-      },
-      {
-        "translation": "or",
-        "count": null
-      },
-      {
-        "translation": "when",
-        "count": null
-      },
-      {
-        "translation": "whether",
-        "count": null
-      },
-      {
-        "translation": "surely",
-        "count": null
-      },
-      {
-        "translation": "doubtless",
-        "count": null
-      },
-      {
-        "translation": "while",
-        "count": null
-      },
-      {
-        "translation": "neither",
-        "count": null
-      },
-      {
-        "translation": "saving",
-        "count": null
-      },
-      {
-        "translation": "verily",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "if",
-      "conditional clauses",
-      "of possible situations",
-      "of impossible situations",
-      "oath contexts",
-      "no, not",
-      "if...if, whether...or, whether...or...or",
-      "when, whenever",
-      "since",
-      "interrogative particle",
-      "but rather"
-    ],
-    "strongs_definition": [
-      "אִם ʼim, eem",
-      "a primitive particle",
-      "used very widely as demonstrative, lo!",
-      "interrogative, whether?",
-      "or conditional, if, although",
-      "also Oh that!, when",
-      "hence, as a negative, not:—(and, can-, doubtless, if, that) (not), + but, either, + except, + more(-over if, than), neither, nevertheless, nor, oh that, or, + save (only, -ing), seeing, since, sith, + surely (no more, none, not), though, + of a truth, + unless, + verily, when, whereas, whether, while, + yet."
     ]
   },
   {
@@ -158391,7 +157403,7 @@
       },
       {
         "translation": "indeed",
-        "count": 2
+        "count": 3
       },
       {
         "translation": "true",
@@ -158403,10 +157415,6 @@
       },
       {
         "translation": "surely",
-        "count": 1
-      },
-      {
-        "translation": "indeed",
         "count": 1
       }
     ],
@@ -159118,46 +158126,6 @@
     ]
   },
   {
-    "concord_id": "H0575",
-    "original_word": "אָן",
-    "transliteration": "'ān",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "whither",
-        "count": null
-      },
-      {
-        "translation": "how",
-        "count": null
-      },
-      {
-        "translation": "where",
-        "count": null
-      },
-      {
-        "translation": "whithersoever",
-        "count": null
-      },
-      {
-        "translation": "hither",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "where?, whither? (of place)",
-      "when?, until when?, how long? (of time)"
-    ],
-    "strongs_definition": [
-      "אָן ʼân, awn",
-      "or אָנָה ʼânâh",
-      "contracted from H370",
-      "where?",
-      "hence, whither?, when?",
-      "also hither and thither:— any (no) whither, now, where, whither(-soever)."
-    ]
-  },
-  {
     "concord_id": "H0576",
     "original_word": "אֲנָא",
     "transliteration": "'ănā'",
@@ -159248,18 +158216,6 @@
       {
         "translation": "deliver",
         "count": 1
-      },
-      {
-        "translation": "befall",
-        "count": null
-      },
-      {
-        "translation": "happen",
-        "count": null
-      },
-      {
-        "translation": "seeketh a quarrel",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -159308,10 +158264,6 @@
       {
         "translation": "these",
         "count": 1
-      },
-      {
-        "translation": "them",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -159481,34 +158433,6 @@
     ]
   },
   {
-    "concord_id": "H0587",
-    "original_word": "אֲנַחְנוּ",
-    "transliteration": "'ănaḥnû",
-    "part_of_speech": "personal pronoun",
-    "english_translations": [
-      {
-        "translation": "we",
-        "count": null
-      },
-      {
-        "translation": "ourselves",
-        "count": null
-      },
-      {
-        "translation": "us",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "we (first pers. pl. - usually used for emphasis)"
-    ],
-    "strongs_definition": [
-      "אֲנַחְנוּ ʼănachnûw, an-akh'-noo",
-      "apparently from H595",
-      "we:—ourselves, us, we."
-    ]
-  },
-  {
     "concord_id": "H0588",
     "original_word": "אֲנָחֲרָת",
     "transliteration": "'ănāḥărāṯ",
@@ -159529,42 +158453,6 @@
       "probably from the same root as H5170",
       "a gorge or narrow pass",
       "Anacharath, a place in Palestine:—Anaharath."
-    ]
-  },
-  {
-    "concord_id": "H0589",
-    "original_word": "אֲנִי",
-    "transliteration": "'ănî",
-    "part_of_speech": "personal pronoun",
-    "english_translations": [
-      {
-        "translation": "I",
-        "count": null
-      },
-      {
-        "translation": "me",
-        "count": null
-      },
-      {
-        "translation": "which",
-        "count": null
-      },
-      {
-        "translation": "for I",
-        "count": null
-      },
-      {
-        "translation": "mine",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "I (first pers. sing. - usually used for emphasis)"
-    ],
-    "strongs_definition": [
-      "אֲנִי ʼănîy, an-ee'",
-      "contracted from H595",
-      "I:—I, (as for) me, mine, myself, we, × which, × who."
     ]
   },
   {
@@ -159606,7 +158494,7 @@
         "count": 31
       },
       {
-        "translation": "shipman (with H582)",
+        "translation": "shipman",
         "count": 1
       }
     ],
@@ -159684,35 +158572,6 @@
       "אֲנָךְ ʼănâk, an-awk'",
       "probably from an unused root meaning to be narrow",
       "according to most a plumb-line, and to others a hook:—plumb-line"
-    ]
-  },
-  {
-    "concord_id": "H0595",
-    "original_word": "אָנֹכִי",
-    "transliteration": "'ānōḵî",
-    "part_of_speech": "personal pronoun",
-    "english_translations": [
-      {
-        "translation": "I",
-        "count": null
-      },
-      {
-        "translation": "which",
-        "count": null
-      },
-      {
-        "translation": "me",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "I (first pers. sing.)"
-    ],
-    "strongs_definition": [
-      "אָנֹכִי ʼânôkîy, aw-no-kee'",
-      "sometimes, אָנֹכִי ʼânôkîy",
-      "a primitive pronoun",
-      "I:—I, me, × which."
     ]
   },
   {
@@ -159941,10 +158800,6 @@
       {
         "translation": "woeful",
         "count": 1
-      },
-      {
-        "translation": "sick",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -159972,7 +158827,7 @@
         "count": 23
       },
       {
-        "translation": "whosoever (with H3606)",
+        "translation": "whosoever",
         "count": 2
       }
     ],
@@ -160721,61 +159576,6 @@
     ]
   },
   {
-    "concord_id": "H0637",
-    "original_word": "אַף",
-    "transliteration": "'ap̄",
-    "part_of_speech": "adverb, conjunction",
-    "english_translations": [
-      {
-        "translation": "also",
-        "count": null
-      },
-      {
-        "translation": "even",
-        "count": null
-      },
-      {
-        "translation": "yet",
-        "count": null
-      },
-      {
-        "translation": "moreover",
-        "count": null
-      },
-      {
-        "translation": "yea",
-        "count": null
-      },
-      {
-        "translation": "with",
-        "count": null
-      },
-      {
-        "translation": "low",
-        "count": null
-      },
-      {
-        "translation": "therefore",
-        "count": null
-      },
-      {
-        "translation": "much",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "also, yea, though, so much the more",
-      "furthermore, indeed"
-    ],
-    "strongs_definition": [
-      "אַף ʼaph, af",
-      "a primitive particle",
-      "meaning accession (used as an adverb or conjunction)",
-      "also or yea",
-      "adversatively though:—also, + although, and (furthermore, yet), but, even, + how much less (more, rather than), moreover, with, yea."
-    ]
-  },
-  {
     "concord_id": "H0638",
     "original_word": "אַף",
     "transliteration": "'ap̄",
@@ -160825,7 +159625,7 @@
         "count": 4
       },
       {
-        "translation": "longsuffering (with H750)",
+        "translation": "longsuffering",
         "count": 4
       },
       {
@@ -160976,7 +159776,7 @@
         "count": 11
       },
       {
-        "translation": "bakemeats (with H4639)",
+        "translation": "bakemeats",
         "count": 1
       }
     ],
@@ -161482,10 +160282,6 @@
       {
         "translation": "forced",
         "count": 1
-      },
-      {
-        "translation": "restrained",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -161904,7 +160700,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "armhole (with H3027)",
+        "translation": "armhole",
         "count": 2
       },
       {
@@ -161939,10 +160735,6 @@
       {
         "translation": "kept",
         "count": 1
-      },
-      {
-        "translation": "straitened",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -162525,11 +161317,11 @@
         "count": 265
       },
       {
-        "translation": "fourteen (with H6240)",
+        "translation": "fourteen",
         "count": 19
       },
       {
-        "translation": "fourteenth (with H6240)",
+        "translation": "fourteenth",
         "count": 23
       },
       {
@@ -162541,7 +161333,7 @@
         "count": 2
       },
       {
-        "translation": "three score and fourteen (with H7657)",
+        "translation": "three score and fourteen",
         "count": 2
       }
     ],
@@ -163709,11 +162501,11 @@
         "count": 9
       },
       {
-        "translation": "longsuffering (with H639)",
+        "translation": "longsuffering",
         "count": 4
       },
       {
-        "translation": "longwinged (with H83)",
+        "translation": "longwinged",
         "count": 1
       },
       {
@@ -163924,11 +162716,11 @@
         "count": 7
       },
       {
-        "translation": "Syriadamascus (with H4601)",
+        "translation": "Syriadamascus",
         "count": 1
       },
       {
-        "translation": "Syriamaachah (with H4601)",
+        "translation": "Syriamaachah",
         "count": 1
       }
     ],
@@ -164382,7 +163174,7 @@
         "count": 1
       },
       {
-        "translation": "wilderness (with H4057)",
+        "translation": "wilderness",
         "count": 1
       }
     ],
@@ -164595,7 +163387,7 @@
     "english_translations": [
       {
         "translation": "fire",
-        "count": 373
+        "count": 374
       },
       {
         "translation": "burning",
@@ -164607,10 +163399,6 @@
       },
       {
         "translation": "untranslated variant",
-        "count": 1
-      },
-      {
-        "translation": "fire (with H800)",
         "count": 1
       },
       {
@@ -165080,15 +163868,11 @@
       },
       {
         "translation": "Assyrian",
-        "count": 19
+        "count": 24
       },
       {
         "translation": "Asshur",
         "count": 8
-      },
-      {
-        "translation": "Assyrian (with H1121)",
-        "count": 5
       },
       {
         "translation": "Assur",
@@ -165877,95 +164661,6 @@
     ]
   },
   {
-    "concord_id": "H0834",
-    "original_word": "אֲשֶׁר",
-    "transliteration": "'ăšer",
-    "part_of_speech": "conjunction, relative pronoun",
-    "english_translations": [
-      {
-        "translation": "which",
-        "count": null
-      },
-      {
-        "translation": "wherewith",
-        "count": null
-      },
-      {
-        "translation": "because",
-        "count": null
-      },
-      {
-        "translation": "when",
-        "count": null
-      },
-      {
-        "translation": "soon",
-        "count": null
-      },
-      {
-        "translation": "whilst",
-        "count": null
-      },
-      {
-        "translation": "as if",
-        "count": null
-      },
-      {
-        "translation": "as when",
-        "count": null
-      },
-      {
-        "translation": "that",
-        "count": null
-      },
-      {
-        "translation": "until",
-        "count": null
-      },
-      {
-        "translation": "much",
-        "count": null
-      },
-      {
-        "translation": "whosoever",
-        "count": null
-      },
-      {
-        "translation": "whereas",
-        "count": null
-      },
-      {
-        "translation": "wherein",
-        "count": null
-      },
-      {
-        "translation": "whom",
-        "count": null
-      },
-      {
-        "translation": "whose",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "(relative part.)",
-      "which, who",
-      "that which",
-      "(conj)",
-      "that (in obj clause)",
-      "when",
-      "since",
-      "as",
-      "conditional if"
-    ],
-    "strongs_definition": [
-      "אֲשֶׁר ʼăsher, ash-er'",
-      "a primitive relative pronoun (of every gender and number)",
-      "who, which, what, that",
-      "also (as an adverb and a conjunction) when, where, how, because, in order that, etc.:—× after, × alike, as (soon as), because, × every, for, + forasmuch, + from whence, + how(-soever), × if, (so) that ((thing) which, wherein), × though, + until, + whatsoever, when, where (+ -as, -in, -of, -on, -soever, -with), which, whilst, + whither(-soever), who(-m, -soever, -se). As it is indeclinable, it is often accompanied by the personal pronoun expletively, used to show the connection."
-    ]
-  },
-  {
     "concord_id": "H0835",
     "original_word": "אֶשֶׁר",
     "transliteration": "'ešer",
@@ -166373,72 +165068,6 @@
     ]
   },
   {
-    "concord_id": "H0853",
-    "original_word": "אֵת",
-    "transliteration": "'ēṯ",
-    "part_of_speech": "particle",
-    "english_translations": [
-      {
-        "translation": "not translated",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "sign of the definite direct object, not translated in English but generally preceding and indicating the accusative"
-    ],
-    "strongs_definition": [
-      "אֵת ʼêth, ayth",
-      "apparent contracted from H226 in the demonstrative sense of entity",
-      "properly, self (but generally used to point out more definitely the object of a verb or preposition, even or namely):—[as such unrepresented in English]."
-    ]
-  },
-  {
-    "concord_id": "H0854",
-    "original_word": "אֵת",
-    "transliteration": "'ēṯ",
-    "part_of_speech": "preposition",
-    "english_translations": [
-      {
-        "translation": "against",
-        "count": null
-      },
-      {
-        "translation": "with",
-        "count": null
-      },
-      {
-        "translation": "in",
-        "count": null
-      },
-      {
-        "translation": "him",
-        "count": null
-      },
-      {
-        "translation": "me",
-        "count": null
-      },
-      {
-        "translation": "upon",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "with, near, together with",
-      "with, together with",
-      "with (of relationship)",
-      "near (of place)",
-      "with (poss.)",
-      "from...with, from (with other prep)"
-    ],
-    "strongs_definition": [
-      "אֵת ʼêth, ayth",
-      "probably from H579",
-      "properly, nearness (used only as a preposition or an adverb), near",
-      "hence, generally, with, by, at, among, etc.:—against, among, before, by, for, from, in(-to), (out) of, with. Often with another prepositional prefix."
-    ]
-  },
-  {
     "concord_id": "H0855",
     "original_word": "אֵת",
     "transliteration": "'ēṯ",
@@ -166537,42 +165166,6 @@
       "אָתָה ʼâthâh, aw-thaw'",
       "(Aramaic) or אָתָא ʼâthâʼ",
       "(Aramaic), corresponding to H857:—(be-) come, bring."
-    ]
-  },
-  {
-    "concord_id": "H0859",
-    "original_word": "אַתָּה",
-    "transliteration": "'atâ",
-    "part_of_speech": "personal pronoun",
-    "english_translations": [
-      {
-        "translation": "thou",
-        "count": null
-      },
-      {
-        "translation": "you",
-        "count": null
-      },
-      {
-        "translation": "ye",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "you (second pers. sing. masc.)"
-    ],
-    "strongs_definition": [
-      "אַתָּה ʼattâh, at-taw'",
-      "or (shortened)",
-      "אַתָּ ʼattâ at-taw'",
-      "or אַת° ʼath, ath",
-      "feminine (irregular) sometimes אַתִּי ʼattîy, at-tee'",
-      "plural masculine אַתֶּם ʼattem, at-tem'",
-      "feminine אַתֶּן ʼatten, at-ten'",
-      "or אַתֵּנָה ʼattênâh, at-tay'-naw",
-      "or אַתֵּנָּה ʼattênnâh, at-tane'-naw",
-      "a primitive pronoun of the second person",
-      "thou and thee, or (plural) ye and you:—thee, thou, ye, you."
     ]
   },
   {
@@ -166692,15 +165285,15 @@
     "part_of_speech": "adverb, substantive",
     "english_translations": [
       {
-        "translation": "time past (with H8032)",
+        "translation": "time past",
         "count": 2
       },
       {
-        "translation": "herefore (with H832)",
+        "translation": "herefore",
         "count": 1
       },
       {
-        "translation": "beforetime (with H8032)",
+        "translation": "beforetime",
         "count": 1
       },
       {
@@ -167249,10 +165842,6 @@
       {
         "translation": "stinking savour",
         "count": 1
-      },
-      {
-        "translation": "utterly 1 (inf. for emphasis)",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -167406,7 +165995,7 @@
         "count": 257
       },
       {
-        "translation": "Babylonian (with H1121)",
+        "translation": "Babylonian",
         "count": 3
       },
       {
@@ -167517,11 +166106,7 @@
         "count": 2
       },
       {
-        "translation": "very 2 (inf. for emphasis)",
-        "count": null
-      },
-      {
-        "translation": "unfaithful man",
+        "translation": "very 2 (inf. for emphasis), unfaithful man",
         "count": 1
       },
       {
@@ -167990,7 +166575,7 @@
         "count": 5
       },
       {
-        "translation": "plummet (with H68)",
+        "translation": "plummet",
         "count": 1
       }
     ],
@@ -168038,10 +166623,6 @@
       {
         "translation": "separation",
         "count": 1
-      },
-      {
-        "translation": "utterly 1 (inf. for emphasis)",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -168162,7 +166743,7 @@
         "count": 8
       },
       {
-        "translation": "calker (with H2388)",
+        "translation": "calker",
         "count": 2
       }
     ],
@@ -169076,15 +167657,11 @@
       },
       {
         "translation": "dungeon",
-        "count": 11
+        "count": 13
       },
       {
         "translation": "well",
         "count": 9
-      },
-      {
-        "translation": "dungeon (with H1004)",
-        "count": 2
       },
       {
         "translation": "fountain",
@@ -169119,11 +167696,7 @@
         "count": 9
       },
       {
-        "translation": "all 2 (inf. for emphasis)",
-        "count": null
-      },
-      {
-        "translation": "confusion",
+        "translation": "all 2 (inf. for emphasis), confusion",
         "count": 1
       },
       {
@@ -169789,10 +168362,6 @@
       {
         "translation": "require",
         "count": 1
-      },
-      {
-        "translation": "not translated",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -170383,53 +168952,6 @@
     ]
   },
   {
-    "concord_id": "H0996",
-    "original_word": "בַּיִן",
-    "transliteration": "bayin",
-    "part_of_speech": "masculine substantive (always used as a preposition)",
-    "english_translations": [
-      {
-        "translation": "between",
-        "count": null
-      },
-      {
-        "translation": "betwixt",
-        "count": null
-      },
-      {
-        "translation": "asunder",
-        "count": null
-      },
-      {
-        "translation": "within",
-        "count": null
-      },
-      {
-        "translation": "between",
-        "count": null
-      },
-      {
-        "translation": "out of",
-        "count": null
-      },
-      {
-        "translation": "from",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "between, among, in the midst of (with other preps), from between"
-    ],
-    "strongs_definition": [
-      "בֵּין bêyn, bane",
-      "(sometimes in the plural masculine or feminine)",
-      "properly, the constructive form of an otherwise unused noun from H995",
-      "a distinction",
-      "but used only as a preposition, between (repeated before each noun, often with other particles)",
-      "also as a conjunction, either...or:—among, asunder, at, between (-twixt...and), + from (the widest), × in, out of, whether (it be...or), within."
-    ]
-  },
-  {
     "concord_id": "H0997",
     "original_word": "בֵּין",
     "transliteration": "bên",
@@ -170635,7 +169157,7 @@
         "count": 3
       },
       {
-        "translation": "families (with H1)",
+        "translation": "families",
         "count": 2
       },
       {
@@ -171356,7 +169878,7 @@
         "count": 31
       },
       {
-        "translation": "Bethlehemjudah (with H3063)",
+        "translation": "Bethlehemjudah",
         "count": 10
       }
     ],
@@ -171892,11 +170414,7 @@
         "count": 2
       },
       {
-        "translation": "all 1 (inf)",
-        "count": null
-      },
-      {
-        "translation": "complain",
+        "translation": "all 1 (inf), complain",
         "count": 1
       },
       {
@@ -171904,11 +170422,7 @@
         "count": 1
       },
       {
-        "translation": "more 1 (inf.)",
-        "count": null
-      },
-      {
-        "translation": "weep over",
+        "translation": "more 1 (inf.), weep over",
         "count": 1
       },
       {
@@ -171962,7 +170476,7 @@
     "english_translations": [
       {
         "translation": "firstborn",
-        "count": 101
+        "count": 102
       },
       {
         "translation": "firstling",
@@ -171971,10 +170485,6 @@
       {
         "translation": "eldest",
         "count": 4
-      },
-      {
-        "translation": "firstborn (with H1121)",
-        "count": 1
       },
       {
         "translation": "eldest son",
@@ -172129,7 +170639,7 @@
         "count": 3
       },
       {
-        "translation": "wept (with H6963)",
+        "translation": "wept",
         "count": 1
       }
     ],
@@ -172223,10 +170733,6 @@
       {
         "translation": "firstling",
         "count": 1
-      },
-      {
-        "translation": "first child",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -172398,57 +170904,6 @@
     ]
   },
   {
-    "concord_id": "H1077",
-    "original_word": "בַּל",
-    "transliteration": "bal",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "none",
-        "count": null
-      },
-      {
-        "translation": "not",
-        "count": null
-      },
-      {
-        "translation": "nor",
-        "count": null
-      },
-      {
-        "translation": "lest",
-        "count": null
-      },
-      {
-        "translation": "nothing",
-        "count": null
-      },
-      {
-        "translation": "not",
-        "count": null
-      },
-      {
-        "translation": "neither",
-        "count": null
-      },
-      {
-        "translation": "no",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "not, hardly, else"
-    ],
-    "strongs_definition": [
-      "בַּל bal, bal",
-      "from H1086",
-      "properly, a failure",
-      "by implication nothing",
-      "usually (adverb) not at all",
-      "also lest:—lest, neither, no, none (that...), not (any), nothing."
-    ]
-  },
-  {
     "concord_id": "H1078",
     "original_word": "בֵּל",
     "transliteration": "bēl",
@@ -172543,11 +170998,7 @@
         "count": 2
       },
       {
-        "translation": "strength",
-        "count": null
-      },
-      {
-        "translation": "strengthen",
+        "translation": "strength, strengthen",
         "count": 1
       }
     ],
@@ -172888,48 +171339,6 @@
     "strongs_definition": [
       "בֵּלְטְשַׁאצַּר Bêlṭᵉshaʼtstsar, bale-tesh-ats-tsar'",
       "(Aramaic) corresponding to H1095:—Belteshazzar."
-    ]
-  },
-  {
-    "concord_id": "H1097",
-    "original_word": "בְּלִי",
-    "transliteration": "bᵊlî",
-    "part_of_speech": "adverb of negation, substantive",
-    "english_translations": [
-      {
-        "translation": "not",
-        "count": null
-      },
-      {
-        "translation": "without",
-        "count": null
-      },
-      {
-        "translation": "un...",
-        "count": null
-      },
-      {
-        "translation": "lack of",
-        "count": null
-      },
-      {
-        "translation": "so that no",
-        "count": null
-      },
-      {
-        "translation": "corruption",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "wearing out",
-      "without, no, not"
-    ],
-    "strongs_definition": [
-      "בְּלִי bᵉlîy, bel-ee'",
-      "from H1086",
-      "properly, failure, i.e. nothing or destruction",
-      "usually (with preposition) without, not yet, because not, as long as, etc.:—corruption, ig(norantly), for lack of, where no...is, so that no, none, not, un(awares), without."
     ]
   },
   {
@@ -173406,64 +171815,6 @@
     ]
   },
   {
-    "concord_id": "H1115",
-    "original_word": "בִּלְתִּי",
-    "transliteration": "biltî",
-    "part_of_speech": "feminine adjective, adverb, substantive",
-    "english_translations": [
-      {
-        "translation": "but",
-        "count": null
-      },
-      {
-        "translation": "except",
-        "count": null
-      },
-      {
-        "translation": "save",
-        "count": null
-      },
-      {
-        "translation": "nothing",
-        "count": null
-      },
-      {
-        "translation": "lest",
-        "count": null
-      },
-      {
-        "translation": "no",
-        "count": null
-      },
-      {
-        "translation": "from",
-        "count": null
-      },
-      {
-        "translation": "inasmuch",
-        "count": null
-      },
-      {
-        "translation": "and not",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "not, except",
-      "not",
-      "except (after preceding negation)",
-      "except (after an implied or expressed negation)",
-      "so as not, in order not",
-      "an account of not, because...not",
-      "until not"
-    ],
-    "strongs_definition": [
-      "בִּלְתִּי biltîy, bil-tee'",
-      "constructive feminine of H1086 (equivalent to H1097)",
-      "properly, a failure of, i.e. (used only as a negative particle, usually with a prepositional prefix) not, except, without, unless, besides, because not, until, etc.:—because un(satiable), beside, but, continual, except, from, lest, neither, no more, none, not, nothing, save, that no, without."
-    ]
-  },
-  {
     "concord_id": "H1116",
     "original_word": "בָּמָה",
     "transliteration": "bāmâ",
@@ -173644,11 +171995,7 @@
       },
       {
         "translation": "young",
-        "count": 18
-      },
-      {
-        "translation": "young (with H1241)",
-        "count": 17
+        "count": 35
       },
       {
         "translation": "child",
@@ -173721,11 +172068,7 @@
         "count": 3
       },
       {
-        "translation": "young",
-        "count": null
-      },
-      {
-        "translation": "of the captives (with H1547)",
+        "translation": "young, of the captives",
         "count": 1
       }
     ],
@@ -173752,7 +172095,7 @@
         "count": 3
       },
       {
-        "translation": "builded (with H1934)",
+        "translation": "builded",
         "count": 1
       },
       {
@@ -173901,10 +172244,6 @@
       {
         "translation": "obtain children",
         "count": 1
-      },
-      {
-        "translation": "surely 1 (inf. for emphasis)",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -174282,11 +172621,7 @@
     "english_translations": [
       {
         "translation": "Benjamite",
-        "count": 16
-      },
-      {
-        "translation": "Benjamite (with H1121)",
-        "count": 1
+        "count": 17
       },
       {
         "translation": "Benjamin",
@@ -174569,59 +172904,6 @@
     ]
   },
   {
-    "concord_id": "H1157",
-    "original_word": "בְּעַד",
-    "transliteration": "bᵊʿaḏ",
-    "part_of_speech": "preposition",
-    "english_translations": [
-      {
-        "translation": "at",
-        "count": null
-      },
-      {
-        "translation": "for",
-        "count": null
-      },
-      {
-        "translation": "by",
-        "count": null
-      },
-      {
-        "translation": "over",
-        "count": null
-      },
-      {
-        "translation": "upon",
-        "count": null
-      },
-      {
-        "translation": "about",
-        "count": null
-      },
-      {
-        "translation": "up",
-        "count": null
-      },
-      {
-        "translation": "through",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "behind, through, round about, on behalf of, away from, about",
-      "through (of action)",
-      "behind (with verbs of shutting)",
-      "about (with verbs of fencing)",
-      "on behalf of (metaph. especially with Hithpael)"
-    ],
-    "strongs_definition": [
-      "בְּעַד bᵉʻad, beh-ad'",
-      "from H5704 with prepositional prefix",
-      "in up to or over against",
-      "generally at, beside, among, behind, for, etc.:—about, at by (means of), for, over, through, up (-on), within."
-    ]
-  },
-  {
     "concord_id": "H1158",
     "original_word": "בָּעָה",
     "transliteration": "bāʿâ",
@@ -174638,10 +172920,6 @@
       {
         "translation": "sought up",
         "count": 1
-      },
-      {
-        "translation": "swelling out",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -174901,11 +173179,11 @@
         "count": 1
       },
       {
-        "translation": "babbler (with H3956)",
+        "translation": "babbler",
         "count": 1
       },
       {
-        "translation": "bird (with H3671)",
+        "translation": "bird",
         "count": 1
       },
       {
@@ -174913,7 +173191,7 @@
         "count": 1
       },
       {
-        "translation": "confederate (with H1285)",
+        "translation": "confederate",
         "count": 1
       },
       {
@@ -174972,7 +173250,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "chancellor (with H2942)",
+        "translation": "chancellor",
         "count": 3
       }
     ],
@@ -176807,10 +175085,6 @@
       {
         "translation": "fail",
         "count": 1
-      },
-      {
-        "translation": "utterly (inf for emphasis",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -176904,22 +175178,14 @@
       },
       {
         "translation": "young",
-        "count": 18
-      },
-      {
-        "translation": "young (with H1121)",
-        "count": 17
+        "count": 35
       },
       {
         "translation": "bullock",
-        "count": 6
+        "count": 8
       },
       {
-        "translation": "bullock (with H1121)",
-        "count": 2
-      },
-      {
-        "translation": "calf (with H1121)",
+        "translation": "calf",
         "count": 2
       },
       {
@@ -176979,7 +175245,7 @@
         "count": 3
       },
       {
-        "translation": "days (with H6153)",
+        "translation": "days",
         "count": 1
       },
       {
@@ -177477,7 +175743,7 @@
         "count": 27
       },
       {
-        "translation": "hailstones (with H68)",
+        "translation": "hailstones",
         "count": 2
       }
     ],
@@ -177551,10 +175817,6 @@
       {
         "translation": "give",
         "count": 1
-      },
-      {
-        "translation": "cause to eat",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -177751,7 +176013,7 @@
         "count": 2
       },
       {
-        "translation": "smith (with H2796)",
+        "translation": "smith",
         "count": 1
       }
     ],
@@ -177813,11 +176075,7 @@
         "count": 1
       },
       {
-        "translation": "fain 1 (inf. for emphasis)",
-        "count": null
-      },
-      {
-        "translation": "flight",
+        "translation": "fain 1 (inf. for emphasis), flight",
         "count": 1
       },
       {
@@ -177950,7 +176208,7 @@
         "count": 2
       },
       {
-        "translation": "fatfleshed (with H1320)",
+        "translation": "fatfleshed",
         "count": 2
       },
       {
@@ -178164,11 +176422,7 @@
       },
       {
         "translation": "confederate",
-        "count": 1
-      },
-      {
-        "translation": "confederate (with H1167)",
-        "count": 1
+        "count": 2
       }
     ],
     "outline_definitions": [
@@ -178932,10 +177186,6 @@
       {
         "translation": "sodden",
         "count": 1
-      },
-      {
-        "translation": "at all 1 (inf. for emphasis)",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -179063,7 +177313,7 @@
         "count": 59
       },
       {
-        "translation": "Bashanhavothjair (with H2334)",
+        "translation": "Bashanhavothjair",
         "count": 1
       }
     ],
@@ -179177,23 +177427,19 @@
         "count": 2
       },
       {
-        "translation": "fatfleshed (with H1277)",
+        "translation": "fatfleshed",
         "count": 2
       },
       {
-        "translation": "leanfleshed (with H1851)",
-        "count": 2
+        "translation": "leanfleshed",
+        "count": 3
       },
       {
         "translation": "kin",
         "count": 2
       },
       {
-        "translation": "leanfleshed (with H7534)",
-        "count": 1
-      },
-      {
-        "translation": "mankind (with H376)",
+        "translation": "mankind",
         "count": 1
       },
       {
@@ -179296,7 +177542,7 @@
     "english_translations": [
       {
         "translation": "daughter",
-        "count": 526
+        "count": 527
       },
       {
         "translation": "town",
@@ -179307,7 +177553,7 @@
         "count": 12
       },
       {
-        "translation": "owl (with H3284)",
+        "translation": "owl",
         "count": 8
       },
       {
@@ -179328,10 +177574,6 @@
       },
       {
         "translation": "company",
-        "count": 1
-      },
-      {
-        "translation": "daughter (with H8676)",
         "count": 1
       },
       {
@@ -180171,7 +178413,7 @@
     "english_translations": [
       {
         "translation": "redeem",
-        "count": 5
+        "count": 6
       },
       {
         "translation": "redemption",
@@ -180183,10 +178425,6 @@
       },
       {
         "translation": "kindred",
-        "count": 1
-      },
-      {
-        "translation": "redeem (with H4672)",
         "count": 1
       },
       {
@@ -183458,7 +181696,7 @@
     "english_translations": [
       {
         "translation": "captivity",
-        "count": 26
+        "count": 27
       },
       {
         "translation": "carry away",
@@ -183474,10 +181712,6 @@
       },
       {
         "translation": "remove",
-        "count": 1
-      },
-      {
-        "translation": "captivity (with H3627)",
         "count": 1
       }
     ],
@@ -183596,15 +181830,11 @@
       },
       {
         "translation": "dead",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "perish",
         "count": 2
-      },
-      {
-        "translation": "dead",
-        "count": 1
       }
     ],
     "outline_definitions": [
@@ -184240,10 +182470,6 @@
       {
         "translation": "robbed",
         "count": 1
-      },
-      {
-        "translation": "that 1",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -186044,11 +184270,11 @@
         "count": 101
       },
       {
-        "translation": "Ramothgilead (with H7433)",
+        "translation": "Ramothgilead",
         "count": 18
       },
       {
-        "translation": "Jabeshgilead (with H3003)",
+        "translation": "Jabeshgilead",
         "count": 12
       },
       {
@@ -186282,7 +184508,7 @@
         "count": 1
       },
       {
-        "translation": "serve (with H1580)",
+        "translation": "serve",
         "count": 1
       },
       {
@@ -187293,7 +185519,7 @@
     "english_translations": [
       {
         "translation": "stranger",
-        "count": 87
+        "count": 89
       },
       {
         "translation": "alien",
@@ -187304,15 +185530,7 @@
         "count": 1
       },
       {
-        "translation": "stranger (with H376)",
-        "count": 1
-      },
-      {
-        "translation": "stranger (with H4480)",
-        "count": 1
-      },
-      {
-        "translation": "strangers (with H582)",
+        "translation": "strangers",
         "count": 1
       }
     ],
@@ -187833,7 +186051,7 @@
         "count": 1
       },
       {
-        "translation": "cornfloor (with H1715)",
+        "translation": "cornfloor",
         "count": 1
       },
       {
@@ -188965,15 +187183,11 @@
       },
       {
         "translation": "slander",
-        "count": 3
+        "count": 4
       },
       {
         "translation": "infamy",
         "count": 2
-      },
-      {
-        "translation": "slander",
-        "count": 1
       }
     ],
     "outline_definitions": [
@@ -189679,12 +187893,8 @@
         "count": 52
       },
       {
-        "translation": "honeycomb (with H3295)",
-        "count": 1
-      },
-      {
-        "translation": "honeycomb (with H6688)",
-        "count": 1
+        "translation": "honeycomb",
+        "count": 2
       }
     ],
     "outline_definitions": [
@@ -189893,7 +188103,7 @@
         "count": 2
       },
       {
-        "translation": "cornfloor (with H1637)",
+        "translation": "cornfloor",
         "count": 1
       }
     ],
@@ -190199,7 +188409,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "fishhook (with H5518)",
+        "translation": "fishhook",
         "count": 1
       }
     ],
@@ -190950,11 +189160,7 @@
         "count": 3
       },
       {
-        "translation": "break",
-        "count": null
-      },
-      {
-        "translation": "tear",
+        "translation": "break, tear",
         "count": 1
       },
       {
@@ -191243,57 +189449,6 @@
       "דַּי day, dahee",
       "of uncertain derivation",
       "enough (as noun or adverb), used chiefly with preposition in phrases:—able, according to, after (ability), among, as (oft as), (more than) enough, from, in, since, (much as is) sufficient(-ly), too much, very, when."
-    ]
-  },
-  {
-    "concord_id": "H1768",
-    "original_word": "דִּי",
-    "transliteration": "dî",
-    "part_of_speech": "conjunction, relative pronoun",
-    "english_translations": [
-      {
-        "translation": "whom",
-        "count": null
-      },
-      {
-        "translation": "that",
-        "count": null
-      },
-      {
-        "translation": "whose",
-        "count": null
-      },
-      {
-        "translation": "for",
-        "count": null
-      },
-      {
-        "translation": "but",
-        "count": null
-      },
-      {
-        "translation": "seeing",
-        "count": null
-      },
-      {
-        "translation": "as",
-        "count": null
-      },
-      {
-        "translation": "when",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "who, which, that",
-      "that of, which belongs to, that",
-      "that, because"
-    ],
-    "strongs_definition": [
-      "דִּי dîy, dee",
-      "(Aramaic) apparently for H1668",
-      "that, used as relative conjunction, and especially (with a preposition) in adverbial phrases",
-      "also as preposition of:—× as, but, for(-asmuch ), now, of, seeing, than, that, therefore, until, what (-soever), when, which, whom, whose."
     ]
   },
   {
@@ -191966,7 +190121,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "wounded in the stones (with H6481)",
+        "translation": "wounded in the stones",
         "count": 1
       }
     ],
@@ -192595,7 +190750,7 @@
         "count": 15
       },
       {
-        "translation": "person (with H5315)",
+        "translation": "person",
         "count": 1
       },
       {
@@ -192603,7 +190758,7 @@
         "count": 1
       },
       {
-        "translation": "bloodthirsty (with H582)",
+        "translation": "bloodthirsty",
         "count": 1
       },
       {
@@ -193451,15 +191606,15 @@
         "count": 1
       },
       {
-        "translation": "unwittingly 2 (with H1097)",
+        "translation": "unwittingly 2",
         "count": 2
       },
       {
-        "translation": "ignorantly (with H1097)",
+        "translation": "ignorantly",
         "count": 1
       },
       {
-        "translation": "unawares (with H1097)",
+        "translation": "unawares",
         "count": 1
       }
     ],
@@ -195329,7 +193484,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "footstool (with H7272)",
+        "translation": "footstool",
         "count": 6
       }
     ],
@@ -195723,70 +193878,6 @@
       "הוֹ hôw, ho",
       "by permutation from H1929",
       "oh!:—alas."
-    ]
-  },
-  {
-    "concord_id": "H1931",
-    "original_word": "הוּא",
-    "transliteration": "hû'",
-    "part_of_speech": "demonstrative pronoun, third person singular personal pronoun",
-    "english_translations": [
-      {
-        "translation": "that",
-        "count": null
-      },
-      {
-        "translation": "him",
-        "count": null
-      },
-      {
-        "translation": "same",
-        "count": null
-      },
-      {
-        "translation": "this",
-        "count": null
-      },
-      {
-        "translation": "he",
-        "count": null
-      },
-      {
-        "translation": "which",
-        "count": null
-      },
-      {
-        "translation": "who",
-        "count": null
-      },
-      {
-        "translation": "such",
-        "count": null
-      },
-      {
-        "translation": "wherein",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "he, she, it",
-      "himself (with emphasis)",
-      "resuming subj with emphasis",
-      "(with minimum emphasis following predicate)",
-      "(anticipating subj)",
-      "(emphasising predicate)",
-      "that, it (neuter)",
-      "that (with article)"
-    ],
-    "strongs_definition": [
-      "הוּא hûwʼ, hoo",
-      "of which the feminine (beyond the Pentateuch) is הִיא hîyʼ",
-      "he a primitive word, the third person pronoun singular",
-      "he (she or it)",
-      "only expressed when emphatic or without a verb",
-      "also (intensively) self, or (especially with the article) the same",
-      "sometimes (as demonstrative) this or that",
-      "occasionally (instead of copula) as or are:—he, as for her, him(-self), it, the same, she (herself), such, that (...it), these, they, this, those, which (is), who."
     ]
   },
   {
@@ -196594,72 +194685,6 @@
     ]
   },
   {
-    "concord_id": "H1961",
-    "original_word": "הָיָה",
-    "transliteration": "hāyâ",
-    "part_of_speech": "verb",
-    "english_translations": [
-      {
-        "translation": "was",
-        "count": null
-      },
-      {
-        "translation": "come to pass",
-        "count": null
-      },
-      {
-        "translation": "came",
-        "count": null
-      },
-      {
-        "translation": "has been",
-        "count": null
-      },
-      {
-        "translation": "were happened",
-        "count": null
-      },
-      {
-        "translation": "become",
-        "count": null
-      },
-      {
-        "translation": "pertained",
-        "count": null
-      },
-      {
-        "translation": "better for thee",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "to be, become, come to pass, exist, happen, fall out",
-      "(Qal)",
-      "—",
-      "to happen, fall out, occur, take place, come about, come to pass",
-      "to come about, come to pass",
-      "to come into being, become",
-      "to arise, appear, come",
-      "to become",
-      "to become",
-      "to become like",
-      "to be instituted, be established",
-      "to be",
-      "to exist, be in existence",
-      "to abide, remain, continue (with word of place or time)",
-      "to stand, lie, be in, be at, be situated (with word of locality)",
-      "to accompany, be with",
-      "(Niphal)",
-      "to occur, come to pass, be done, be brought about",
-      "to be done, be finished, be gone"
-    ],
-    "strongs_definition": [
-      "הָיָה hâyâh, haw-yaw",
-      "a primitive root (compare H1933)",
-      "to exist, i.e. be or become, come to pass (always emphatic, and not a mere copula or auxiliary):—beacon, × altogether, be(-come), accomplished, committed, like), break, cause, come (to pass), do, faint, fall, follow, happen, × have, last, pertain, quit (one-) self, require, × use."
-    ]
-  },
-  {
     "concord_id": "H1962",
     "original_word": "הַיָּה",
     "transliteration": "hayyâ",
@@ -196991,7 +195016,7 @@
         "count": 2
       },
       {
-        "translation": "other side (with H5676)",
+        "translation": "other side",
         "count": 1
       }
     ],
@@ -197488,55 +195513,6 @@
     ]
   },
   {
-    "concord_id": "H1992",
-    "original_word": "הֵם",
-    "transliteration": "hēm",
-    "part_of_speech": "third person plural masculine personal pronoun",
-    "english_translations": [
-      {
-        "translation": "they",
-        "count": null
-      },
-      {
-        "translation": "them",
-        "count": null
-      },
-      {
-        "translation": "themselves",
-        "count": null
-      },
-      {
-        "translation": "these",
-        "count": null
-      },
-      {
-        "translation": "those",
-        "count": null
-      },
-      {
-        "translation": "as many more as",
-        "count": null
-      },
-      {
-        "translation": "ye",
-        "count": null
-      },
-      {
-        "translation": "same",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "they, these, the same, who"
-    ],
-    "strongs_definition": [
-      "הֵם hêm, haym",
-      "or (prolonged) הֵמָּה hêmmâh",
-      "masculine plural from H1931",
-      "they (only used when emphatic):—it, like, × (how, so) many (soever, more as) they (be), (the) same, × so, × such, their, them, these, they, those, which, who, whom, withal, ye."
-    ]
-  },
-  {
     "concord_id": "H1993",
     "original_word": "הָמָֽה",
     "transliteration": "hāmâ",
@@ -197634,7 +195610,7 @@
         "count": 7
       },
       {
-        "translation": "set (with H3488)",
+        "translation": "set",
         "count": 1
       },
       {
@@ -197646,7 +195622,7 @@
         "count": 1
       },
       {
-        "translation": "men (with H1400)",
+        "translation": "men",
         "count": 1
       }
     ],
@@ -197982,44 +195958,6 @@
     ]
   },
   {
-    "concord_id": "H2005",
-    "original_word": "הֵן",
-    "transliteration": "hēn",
-    "part_of_speech": "hypothetical participle, interjection",
-    "english_translations": [
-      {
-        "translation": "lo",
-        "count": null
-      },
-      {
-        "translation": "behold",
-        "count": null
-      },
-      {
-        "translation": "if",
-        "count": null
-      },
-      {
-        "translation": "or if",
-        "count": null
-      },
-      {
-        "translation": "though",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "behold, lo, though",
-      "if"
-    ],
-    "strongs_definition": [
-      "הֵן hên, hane",
-      "a primitive particle",
-      "lo!",
-      "also (as expressing surprise) if:—behold, if, lo, though."
-    ]
-  },
-  {
     "concord_id": "H2006",
     "original_word": "הֵן",
     "transliteration": "hēn",
@@ -198045,98 +195983,6 @@
       "הֵן hên, hane",
       "(Aramaic) corresponding to H2005",
       "lo! also there(-fore), (un-) less, whether, but, if:—(that) if, or, whether."
-    ]
-  },
-  {
-    "concord_id": "H2007",
-    "original_word": "הֵנָּה",
-    "transliteration": "hēnnâ",
-    "part_of_speech": "third person plural feminine personal pronoun",
-    "english_translations": [
-      {
-        "translation": "they",
-        "count": null
-      },
-      {
-        "translation": "their",
-        "count": null
-      },
-      {
-        "translation": "those",
-        "count": null
-      },
-      {
-        "translation": "this side",
-        "count": null
-      },
-      {
-        "translation": "them",
-        "count": null
-      },
-      {
-        "translation": "such",
-        "count": null
-      },
-      {
-        "translation": "these",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "they, these, the same, who"
-    ],
-    "strongs_definition": [
-      "הֵנָּה hênnâh, hane'-naw",
-      "prolongation for H2004",
-      "themselves (often used emphatic for the copula, also in indirect relation):—× in, × such (and such things), their, (into) them, thence, therein, these, they (had), on this side, whose, wherein."
-    ]
-  },
-  {
-    "concord_id": "H2008",
-    "original_word": "הֵנָּה",
-    "transliteration": "hēnnâ",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "hither",
-        "count": null
-      },
-      {
-        "translation": "here",
-        "count": null
-      },
-      {
-        "translation": "now",
-        "count": null
-      },
-      {
-        "translation": "way",
-        "count": null
-      },
-      {
-        "translation": "to...fro",
-        "count": null
-      },
-      {
-        "translation": "since",
-        "count": null
-      },
-      {
-        "translation": "hitherto",
-        "count": null
-      },
-      {
-        "translation": "thus far",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "here, there, now, hither"
-    ],
-    "strongs_definition": [
-      "הֵנָּה hênnâh, hane'-naw",
-      "from H2004",
-      "hither or thither (but used both of place and time):—here, hither(-to), now, on this (that) side, since, this (that) way, thitherward, thus far, to...fro, yet."
     ]
   },
   {
@@ -199528,80 +197374,6 @@
     ]
   },
   {
-    "concord_id": "H2063",
-    "original_word": "זֹאת",
-    "transliteration": "zō'ṯ",
-    "part_of_speech": "adverb, demonstrative pronoun",
-    "english_translations": [
-      {
-        "translation": "this",
-        "count": null
-      },
-      {
-        "translation": "her",
-        "count": null
-      },
-      {
-        "translation": "thus",
-        "count": null
-      },
-      {
-        "translation": "herein",
-        "count": null
-      },
-      {
-        "translation": "the same",
-        "count": null
-      },
-      {
-        "translation": "herewith",
-        "count": null
-      },
-      {
-        "translation": "that",
-        "count": null
-      },
-      {
-        "translation": "such",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "this, this one, here, which, this...that, the one...the other, such",
-      "(alone)",
-      "this one",
-      "this...that, the one...the other, another",
-      "(appos to subst)",
-      "this",
-      "(as predicate)",
-      "this, such",
-      "(enclitically)",
-      "then",
-      "who, whom",
-      "how now, what now",
-      "what now",
-      "wherefore now",
-      "behold here",
-      "just now",
-      "now, now already",
-      "(poetry)",
-      "wherein, which, those who",
-      "(with prefixes)",
-      "in this (place) here, then",
-      "on these conditions, herewith, thus provided, by, through this, for this cause, in this matter",
-      "thus and thus",
-      "as follows, things such as these, accordingly, to that effect, in like manner, thus and thus",
-      "from here, hence, on one side...on the other side",
-      "on this account",
-      "in spite of this, which, whence, how"
-    ],
-    "strongs_definition": [
-      "זֹאת zôʼth, zothe'",
-      "irregular feminine of H2088",
-      "this (often used adverb):—hereby (-in, -with), it, likewise, the one (other, same), she, so (much), such (deed), that, therefore, these, this (thing), thus."
-    ]
-  },
-  {
     "concord_id": "H2064",
     "original_word": "זָבַד",
     "transliteration": "zāḇaḏ",
@@ -200189,84 +197961,6 @@
       "זָדוֹן zâdôwn, zaw-done'",
       "from H2102",
       "arrogance:—presumptuously, pride, proud (man)."
-    ]
-  },
-  {
-    "concord_id": "H2088",
-    "original_word": "זֶה",
-    "transliteration": "zê",
-    "part_of_speech": "demonstrative pronoun",
-    "english_translations": [
-      {
-        "translation": "this",
-        "count": null
-      },
-      {
-        "translation": "thus",
-        "count": null
-      },
-      {
-        "translation": "these",
-        "count": null
-      },
-      {
-        "translation": "such",
-        "count": null
-      },
-      {
-        "translation": "very",
-        "count": null
-      },
-      {
-        "translation": "hath",
-        "count": null
-      },
-      {
-        "translation": "hence",
-        "count": null
-      },
-      {
-        "translation": "side",
-        "count": null
-      },
-      {
-        "translation": "same",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "this, this one, here, which, this...that, the one...the other, another, such",
-      "(alone)",
-      "this one",
-      "this...that, the one...the other, another",
-      "(appos to subst)",
-      "this",
-      "(as predicate)",
-      "this, such",
-      "(enclitically)",
-      "then",
-      "who, whom",
-      "how now, what now",
-      "what now",
-      "wherefore now",
-      "behold here",
-      "just now",
-      "now, now already",
-      "(poetry)",
-      "wherein, which, those who",
-      "(with prefixes)",
-      "in this (place) here, then",
-      "on these conditions, herewith, thus provided, by, through this, for this cause, in this matter",
-      "thus and thus",
-      "as follows, things such as these, accordingly, to that effect, in like manner, thus and thus",
-      "from here, hence, on one side...on the other side",
-      "on this account",
-      "in spite of this, which, whence, how"
-    ],
-    "strongs_definition": [
-      "זֶה zeh, zeh",
-      "a primitive word",
-      "the masculine demonstrative pronoun, this or that:—he, × hence, × here, it(-self), × now, × of him, the one...the other, × than the other, (× out of) the (self) same, such (a one) that, these, this (hath, man), on this side...on that side, × thus, very, which. Compare H2063, H2090, H2097, H2098."
     ]
   },
   {
@@ -200960,7 +198654,7 @@
     "english_translations": [
       {
         "translation": "stranger",
-        "count": 45
+        "count": 48
       },
       {
         "translation": "strange",
@@ -200969,10 +198663,6 @@
       {
         "translation": "estranged",
         "count": 4
-      },
-      {
-        "translation": "stranger (with H376)",
-        "count": 3
       },
       {
         "translation": "another",
@@ -201927,57 +199617,6 @@
     ]
   },
   {
-    "concord_id": "H2148",
-    "original_word": "זְכַרְיָה",
-    "transliteration": "zᵊḵaryâ",
-    "part_of_speech": "proper masculine noun",
-    "english_translations": [
-      {
-        "translation": "Zechariah",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "Zechariah = \"Jehovah remembers\"",
-      "11th in order of the minor prophets; a priest, son of Berechiah and grandson of Iddo, who, along with Haggai, directed the rebuilding of the temple in the days of Zerubbabel",
-      "king of Israel, son of Jeroboam II",
-      "son of Meshelemiah of Shelemiah, a Korhite, and keeper of the north gate of the tabernacle of the congregation",
-      "one of the sons of Jehiel",
-      "a Levite of the second order in the temple band in the time of David",
-      "one of the princes of Judah in the reign of Jehoshaphat",
-      "son of the high priest Jehoiada, in the reign of Joash king of Judah, who was stoned in the court of the temple",
-      "a Kohathite Levite in the reign of Josiah",
-      "the leader of the sons of Pharosh who returned with Ezra",
-      "son of Bebai",
-      "one of the chiefs of the people whom Ezra summoned in council at the river Ahava; stood at Ezra's left hand when Ezra expounded the law to the people",
-      "one of the family of Elam who had married a foreign wife after the captivity",
-      "ancestor of Athaiah or Uthai",
-      "a Shilonite, descendant of Perez, grandfather of Athaiah",
-      "a priest, son of Pashur",
-      "the representative of the priestly family of Iddo in the days of Joiakim the son of Jeshua; possibly the same as 1 above",
-      "one of the priests, son of Jonathan, who blew with the trumpets at the dedication of the city wall by Ezra and Nehemiah",
-      "a chief of the Reubenites at the time of the captivity by Tiglath-pileser",
-      "one of the priests who accompanied the ark from the house of Obed-edom",
-      "son of Isshiah of Jesiah, a Kohathite Levite descended from Uzziel",
-      "4th son of Hosah, of the children of Merari",
-      "a Manassite, father of Iddo",
-      "father of Jahaziel. He prophesied in the spirit",
-      "one of the sons of Jehoshaphat",
-      "a prophet in the reign of Uzziah, who appears to have acted as the king's counsellor, but of whom nothing is known",
-      "father of Abijah or Abi, Hezekiah's mother",
-      "one of the family of Asaph in the reign of Hezekiah",
-      "one of the rulers of the temple in the reign of Josiah",
-      "son of Jeberechiah who was taken by the prophet Isaiah as one of the 'faithful witnesses to record' when he wrote concerning Maher-shalal-hash-baz"
-    ],
-    "strongs_definition": [
-      "זְכַרְיָה Zᵉkaryâh, zek-ar-yaw'",
-      "or זְכַרְיָהוּ Zᵉkaryâhûw",
-      "from H2142 and H3050",
-      "Jah has remembered",
-      "Zecarjah, the name of twenty-nine Israelites:—Zachariah, Zechariah."
-    ]
-  },
-  {
     "concord_id": "H2149",
     "original_word": "זֻלּוּת",
     "transliteration": "zullûṯ",
@@ -202087,28 +199726,6 @@
       "from H2196",
       "a glow (of wind or anger)",
       "also a famine (as consuming):—horrible, horror, terrible."
-    ]
-  },
-  {
-    "concord_id": "H2153",
-    "original_word": "זִלְפָּה",
-    "transliteration": "zilpâ",
-    "part_of_speech": "proper feminine noun",
-    "english_translations": [
-      {
-        "translation": "Zilpah",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "Zilpah = \"a trickling\"",
-      "the Syrian given by Laban to Leah as a handmaid, a concubine of Jacob, mother of Asher and Gad"
-    ],
-    "strongs_definition": [
-      "זִלְפָּה Zilpâh, zil-paw",
-      "from an unused root apparently meaning to trickle, as myrrh",
-      "fragrant dropping",
-      "Zilpah, Leah's maid:—Zilpah."
     ]
   },
   {
@@ -202821,7 +200438,7 @@
         "count": 3
       },
       {
-        "translation": "harlot (with H802)",
+        "translation": "harlot",
         "count": 2
       },
       {
@@ -202837,7 +200454,7 @@
         "count": 1
       },
       {
-        "translation": "whore's (with H802)",
+        "translation": "whore's",
         "count": 1
       }
     ],
@@ -202964,10 +200581,6 @@
       {
         "translation": "turn...away",
         "count": 1
-      },
-      {
-        "translation": "removed...far off",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -204277,12 +201890,8 @@
         "count": 2
       },
       {
-        "translation": "carnally (with H7902)",
-        "count": 2
-      },
-      {
         "translation": "carnally",
-        "count": 1
+        "count": 3
       },
       {
         "translation": "fruitful",
@@ -205056,7 +202665,7 @@
         "count": 4
       },
       {
-        "translation": "shipmaster (with H7227)",
+        "translation": "shipmaster",
         "count": 1
       }
     ],
@@ -205228,11 +202837,11 @@
         "count": 1
       },
       {
-        "translation": "charmer (with H2267)",
+        "translation": "charmer",
         "count": 1
       },
       {
-        "translation": "charming (with H2267)",
+        "translation": "charming",
         "count": 1
       },
       {
@@ -205288,11 +202897,11 @@
         "count": 1
       },
       {
-        "translation": "charmer (with H2266)",
+        "translation": "charmer",
         "count": 1
       },
       {
-        "translation": "charming (with H2266)",
+        "translation": "charming",
         "count": 1
       }
     ],
@@ -206566,12 +204175,8 @@
         "count": 4
       },
       {
-        "translation": "bedchamber (with G4296)",
-        "count": 3
-      },
-      {
-        "translation": "bedchamber (with G4904)",
-        "count": 3
+        "translation": "bedchamber",
+        "count": 6
       },
       {
         "translation": "inward parts",
@@ -207033,7 +204638,7 @@
         "count": 2
       },
       {
-        "translation": "Bashanhavothjair (with H1316)",
+        "translation": "Bashanhavothjair",
         "count": 1
       }
     ],
@@ -207536,7 +205141,7 @@
         "count": 1
       },
       {
-        "translation": "Kirjathhuzoth (with H7155)",
+        "translation": "Kirjathhuzoth",
         "count": 1
       },
       {
@@ -207997,12 +205602,12 @@
         "count": 17
       },
       {
-        "translation": "saw (with H1934)",
+        "translation": "saw",
         "count": 6
       },
       {
-        "translation": "beheld (with H1934)",
-        "count": 5
+        "translation": "beheld",
+        "count": 6
       },
       {
         "translation": "had",
@@ -208010,10 +205615,6 @@
       },
       {
         "translation": "wont",
-        "count": 1
-      },
-      {
-        "translation": "beheld",
         "count": 1
       }
     ],
@@ -208483,7 +206084,7 @@
       },
       {
         "translation": "hold",
-        "count": 37
+        "count": 42
       },
       {
         "translation": "strengthened",
@@ -208519,10 +206120,6 @@
       },
       {
         "translation": "stronger",
-        "count": 5
-      },
-      {
-        "translation": "hold",
         "count": 5
       },
       {
@@ -211135,7 +208732,7 @@
         "count": 64
       },
       {
-        "translation": "dreamer (with H1167)",
+        "translation": "dreamer",
         "count": 1
       }
     ],
@@ -212996,7 +210593,7 @@
       },
       {
         "translation": "furious",
-        "count": 4
+        "count": 5
       },
       {
         "translation": "displeasure",
@@ -213012,10 +210609,6 @@
       },
       {
         "translation": "bottles",
-        "count": 1
-      },
-      {
-        "translation": "furious (with H1167)",
         "count": 1
       },
       {
@@ -213585,7 +211178,7 @@
         "count": 1
       },
       {
-        "translation": "oppressor (with H376)",
+        "translation": "oppressor",
         "count": 1
       },
       {
@@ -213650,15 +211243,11 @@
     "english_translations": [
       {
         "translation": "leaven",
-        "count": 5
+        "count": 7
       },
       {
         "translation": "leavened bread",
         "count": 4
-      },
-      {
-        "translation": "leaven",
-        "count": 2
       }
     ],
     "outline_definitions": [
@@ -213856,7 +211445,7 @@
         "count": 2
       },
       {
-        "translation": "slimepit (with H875)",
+        "translation": "slimepit",
         "count": 1
       }
     ],
@@ -213943,20 +211532,16 @@
         "count": 300
       },
       {
-        "translation": "fifteenth (with H6240)",
+        "translation": "fifteenth",
         "count": 16
       },
       {
-        "translation": "fifteen (with H6240)",
-        "count": 15
+        "translation": "fifteen",
+        "count": 18
       },
       {
         "translation": "fifth",
         "count": 6
-      },
-      {
-        "translation": "fifteen (with H7657)",
-        "count": 3
       },
       {
         "translation": "variant",
@@ -214052,7 +211637,7 @@
     "english_translations": [
       {
         "translation": "fifty",
-        "count": 151
+        "count": 152
       },
       {
         "translation": "fifties",
@@ -214061,10 +211646,6 @@
       {
         "translation": "fiftieth",
         "count": 4
-      },
-      {
-        "translation": "fifty (with H376)",
-        "count": 1
       }
     ],
     "outline_definitions": [
@@ -214107,11 +211688,7 @@
     "english_translations": [
       {
         "translation": "Hamath",
-        "count": 34
-      },
-      {
-        "translation": "Hamath",
-        "count": 3
+        "count": 37
       }
     ],
     "outline_definitions": [
@@ -214262,7 +211839,7 @@
         "count": 1
       },
       {
-        "translation": "wellfavoured (with H2896)",
+        "translation": "wellfavoured",
         "count": 1
       }
     ],
@@ -215123,10 +212700,6 @@
       {
         "translation": "corrupt",
         "count": 1
-      },
-      {
-        "translation": "profane 1",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -215504,7 +213077,7 @@
         "count": 1
       },
       {
-        "translation": "ungodly (with H3808)",
+        "translation": "ungodly",
         "count": 1
       }
     ],
@@ -216806,7 +214379,7 @@
         "count": 48
       },
       {
-        "translation": "archers (with H1167)",
+        "translation": "archers",
         "count": 1
       },
       {
@@ -216975,11 +214548,7 @@
     "part_of_speech": "proper locative noun",
     "english_translations": [
       {
-        "translation": "Hazor",
-        "count": null
-      },
-      {
-        "translation": "Hadattah",
+        "translation": "Hazor, Hadattah",
         "count": 1
       }
     ],
@@ -217000,7 +214569,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "midnight (with H3915)",
+        "translation": "midnight",
         "count": 3
       }
     ],
@@ -217032,7 +214601,7 @@
         "count": 4
       },
       {
-        "translation": "midnight (with H3915)",
+        "translation": "midnight",
         "count": 4
       },
       {
@@ -217201,11 +214770,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "lap",
-        "count": null
-      },
-      {
-        "translation": "arms",
+        "translation": "lap, arms",
         "count": 1
       }
     ],
@@ -217364,7 +214929,7 @@
     "english_translations": [
       {
         "translation": "sounded",
-        "count": 2
+        "count": 3
       },
       {
         "translation": "blow",
@@ -217376,10 +214941,6 @@
       },
       {
         "translation": "trumpeters",
-        "count": 1
-      },
-      {
-        "translation": "sounded",
         "count": 1
       },
       {
@@ -217959,10 +215520,6 @@
       {
         "translation": "note",
         "count": 1
-      },
-      {
-        "translation": "appoint",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -218100,11 +215657,7 @@
       },
       {
         "translation": "unsearchable",
-        "count": 2
-      },
-      {
-        "translation": "unsearchable (with H369)",
-        "count": 1
+        "count": 3
       },
       {
         "translation": "finding out",
@@ -218268,7 +215821,7 @@
     "english_translations": [
       {
         "translation": "sword",
-        "count": 401
+        "count": 402
       },
       {
         "translation": "knife",
@@ -218288,10 +215841,6 @@
       },
       {
         "translation": "TOOL",
-        "count": 1
-      },
-      {
-        "translation": "sword (with H3027)",
         "count": 1
       }
     ],
@@ -219950,7 +217499,7 @@
         "count": 1
       },
       {
-        "translation": "winterhouse (with H1004)",
+        "translation": "winterhouse",
         "count": 1
       }
     ],
@@ -220488,7 +218037,7 @@
       },
       {
         "translation": "smith",
-        "count": 2
+        "count": 3
       },
       {
         "translation": "makers",
@@ -220496,10 +218045,6 @@
       },
       {
         "translation": "skilful",
-        "count": 1
-      },
-      {
-        "translation": "smith (with H1270)",
         "count": 1
       },
       {
@@ -221653,7 +219198,7 @@
     "english_translations": [
       {
         "translation": "desire",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "that",
@@ -221661,10 +219206,6 @@
       },
       {
         "translation": "pleasure",
-        "count": 1
-      },
-      {
-        "translation": "desire (with H2836)",
         "count": 1
       }
     ],
@@ -223203,7 +220744,7 @@
         "count": 1
       },
       {
-        "translation": "pleased (with H5869)",
+        "translation": "pleased",
         "count": 1
       }
     ],
@@ -223657,7 +221198,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "bowshot (with H7198)",
+        "translation": "bowshot",
         "count": 1
       }
     ],
@@ -224533,11 +222074,11 @@
         "count": 13
       },
       {
-        "translation": "chancellor (with H1169)",
+        "translation": "chancellor",
         "count": 3
       },
       {
-        "translation": "commanded (with H7761)",
+        "translation": "commanded",
         "count": 3
       },
       {
@@ -225006,39 +222547,6 @@
       "from an unused root apparently meaning to be moist",
       "properly, dripping",
       "hence, fresh (i.e. recently made such):—new, putrefying."
-    ]
-  },
-  {
-    "concord_id": "H2962",
-    "original_word": "טֶרֶם",
-    "transliteration": "ṭerem",
-    "part_of_speech": "preposition",
-    "english_translations": [
-      {
-        "translation": "before",
-        "count": null
-      },
-      {
-        "translation": "ere",
-        "count": null
-      },
-      {
-        "translation": "not yet",
-        "count": null
-      },
-      {
-        "translation": "neither",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "before, not yet, before that"
-    ],
-    "strongs_definition": [
-      "טֶרֶם ṭerem, teh'-rem",
-      "from an unused root apparently meaning to interrupt or suspend",
-      "properly, non-occurrence",
-      "used adverbially, not yet or before:—before, ere, not yet."
     ]
   },
   {
@@ -226713,7 +224221,7 @@
         "count": 44
       },
       {
-        "translation": "consecrate (with H4390)",
+        "translation": "consecrate",
         "count": 14
       },
       {
@@ -227528,7 +225036,7 @@
         "count": 21
       },
       {
-        "translation": "given (with H1934)",
+        "translation": "given",
         "count": 2
       },
       {
@@ -227803,7 +225311,7 @@
         "count": 808
       },
       {
-        "translation": "Bethlehemjudah (with H1035)",
+        "translation": "Bethlehemjudah",
         "count": 10
       }
     ],
@@ -227834,11 +225342,7 @@
     "english_translations": [
       {
         "translation": "Jew",
-        "count": 74
-      },
-      {
-        "translation": "Jew (with H376)",
-        "count": 1
+        "count": 75
       },
       {
         "translation": "Judah",
@@ -229161,7 +226665,7 @@
         "count": 64
       },
       {
-        "translation": "chronicles (with H1697)",
+        "translation": "chronicles",
         "count": 37
       },
       {
@@ -229387,7 +226891,7 @@
         "count": 10
       },
       {
-        "translation": "variant (with H1686)",
+        "translation": "variant",
         "count": 1
       }
     ],
@@ -230964,10 +228468,6 @@
       {
         "translation": "genealogy",
         "count": 6
-      },
-      {
-        "translation": "number...genealogy 2",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -231218,7 +228718,7 @@
         "count": 1
       },
       {
-        "translation": "winebibbers (with H5433)",
+        "translation": "winebibbers",
         "count": 1
       }
     ],
@@ -231283,7 +228783,7 @@
         "count": 2
       },
       {
-        "translation": "reprover (with H376)",
+        "translation": "reprover",
         "count": 2
       },
       {
@@ -231446,7 +228946,7 @@
         "count": 1
       },
       {
-        "translation": "cannot (with H3809)",
+        "translation": "cannot",
         "count": 1
       }
     ],
@@ -231765,7 +229265,7 @@
         "count": 2
       },
       {
-        "translation": "homeborn (with H1004)",
+        "translation": "homeborn",
         "count": 1
       }
     ],
@@ -232163,7 +229663,7 @@
         "count": 3
       },
       {
-        "translation": "lefthanded (with H334)",
+        "translation": "lefthanded",
         "count": 2
       }
     ],
@@ -232501,10 +230001,6 @@
       {
         "translation": "oppression",
         "count": 1
-      },
-      {
-        "translation": "thrust out",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -232766,7 +230262,7 @@
     "english_translations": [
       {
         "translation": "foundation",
-        "count": 15
+        "count": 16
       },
       {
         "translation": "lay",
@@ -232787,10 +230283,6 @@
       {
         "translation": "established",
         "count": 2
-      },
-      {
-        "translation": "foundation (with H3117)",
-        "count": 1
       },
       {
         "translation": "appointed",
@@ -233792,54 +231284,6 @@
     ]
   },
   {
-    "concord_id": "H3282",
-    "original_word": "יַעַן",
-    "transliteration": "yaʿan",
-    "part_of_speech": "conjunction, preposition",
-    "english_translations": [
-      {
-        "translation": "because",
-        "count": null
-      },
-      {
-        "translation": "even",
-        "count": null
-      },
-      {
-        "translation": "seeing",
-        "count": null
-      },
-      {
-        "translation": "forasmuch",
-        "count": null
-      },
-      {
-        "translation": "that",
-        "count": null
-      },
-      {
-        "translation": "whereas",
-        "count": null
-      },
-      {
-        "translation": "why",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "because, therefore, because that, on account of",
-      "because of, on account of",
-      "why (with interrogative pron)"
-    ],
-    "strongs_definition": [
-      "יַעַן yaʻan, yah'-an",
-      "from an unused root meaning to pay attention",
-      "properly, heed",
-      "by implication, purpose (sake or account)",
-      "used adverbially to indicate the reason or cause:—because (that), forasmuch (+ as), seeing then, + that, + whereas, + why."
-    ]
-  },
-  {
     "concord_id": "H3283",
     "original_word": "יָעֵן",
     "transliteration": "yāʿēn",
@@ -234282,11 +231726,7 @@
     "english_translations": [
       {
         "translation": "Jaasiel",
-        "count": 1
-      },
-      {
-        "translation": "Jaasiel",
-        "count": 1
+        "count": 2
       }
     ],
     "outline_definitions": [
@@ -234371,7 +231811,7 @@
       },
       {
         "translation": "beautiful",
-        "count": 5
+        "count": 7
       },
       {
         "translation": "well",
@@ -234387,15 +231827,7 @@
       },
       {
         "translation": "beauty",
-        "count": 1
-      },
-      {
-        "translation": "beautiful (with H8389)",
         "count": 2
-      },
-      {
-        "translation": "beauty",
-        "count": 1
       },
       {
         "translation": "comely",
@@ -236438,7 +233870,7 @@
         "count": 41
       },
       {
-        "translation": "exceedingly (with H1419)",
+        "translation": "exceedingly",
         "count": 2
       },
       {
@@ -236604,15 +234036,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(come",
-        "count": null
-      },
-      {
-        "translation": "go",
-        "count": null
-      },
-      {
-        "translation": "etc) down",
+        "translation": "(come, go, etc) down",
         "count": 340
       },
       {
@@ -239553,7 +236977,7 @@
     "part_of_speech": "adjective patrial",
     "english_translations": [
       {
-        "translation": "Israel (with G3478)",
+        "translation": "Israel",
         "count": 1
       },
       {
@@ -240695,15 +238119,7 @@
         "count": 8
       },
       {
-        "translation": "(go",
-        "count": null
-      },
-      {
-        "translation": "put",
-        "count": null
-      },
-      {
-        "translation": "..) out",
+        "translation": "(go, put, ..) out",
         "count": 7
       }
     ],
@@ -240882,7 +238298,7 @@
         "count": 1
       },
       {
-        "translation": "valiant (with H47)",
+        "translation": "valiant",
         "count": 1
       },
       {
@@ -241279,51 +238695,6 @@
     ]
   },
   {
-    "concord_id": "H3541",
-    "original_word": "כֹּה",
-    "transliteration": "kô",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "thus",
-        "count": null
-      },
-      {
-        "translation": "so...also",
-        "count": null
-      },
-      {
-        "translation": "like",
-        "count": null
-      },
-      {
-        "translation": "hitherto",
-        "count": null
-      },
-      {
-        "translation": "while",
-        "count": null
-      },
-      {
-        "translation": "on this manner",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "thus, here, in this manner",
-      "thus, so",
-      "here, here and there",
-      "until now, until now...until then, meanwhile"
-    ],
-    "strongs_definition": [
-      "כֹּה kôh, ko",
-      "from the prefix k and H1931",
-      "properly, like this, i.e. by implication, (of manner) thus (or so)",
-      "also (of place) here (or hither)",
-      "or (of time) now:—also, here, hitherto, like, on the other side, so (and much), such, on that manner, (on) this (manner, side, way, way and that way), mean while, yonder."
-    ]
-  },
-  {
     "concord_id": "H3542",
     "original_word": "כֹּה",
     "transliteration": "kô",
@@ -241705,7 +239076,7 @@
         "count": 36
       },
       {
-        "translation": "stargazers (with H2374)",
+        "translation": "stargazers",
         "count": 1
       }
     ],
@@ -242363,7 +239734,7 @@
         "count": 1
       },
       {
-        "translation": "lies (with H1697)",
+        "translation": "lies",
         "count": 1
       }
     ],
@@ -242471,11 +239842,7 @@
       },
       {
         "translation": "able",
-        "count": 2
-      },
-      {
-        "translation": "able (with H6113)",
-        "count": 1
+        "count": 3
       },
       {
         "translation": "chameleon",
@@ -242498,7 +239865,7 @@
         "count": 1
       },
       {
-        "translation": "weary (with H3019)",
+        "translation": "weary",
         "count": 1
       }
     ],
@@ -242720,70 +240087,6 @@
       "כִּי kîy, kee",
       "from H3554",
       "a brand or scar:—burning."
-    ]
-  },
-  {
-    "concord_id": "H3588",
-    "original_word": "כִּי",
-    "transliteration": "kî",
-    "part_of_speech": "conjunction",
-    "english_translations": [
-      {
-        "translation": "that",
-        "count": null
-      },
-      {
-        "translation": "because",
-        "count": null
-      },
-      {
-        "translation": "for",
-        "count": null
-      },
-      {
-        "translation": "if",
-        "count": null
-      },
-      {
-        "translation": "surely",
-        "count": null
-      },
-      {
-        "translation": "except",
-        "count": null
-      },
-      {
-        "translation": "yea",
-        "count": null
-      },
-      {
-        "translation": "doubtless",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "that, for, because, when, as though, as, because that, but, then, certainly, except, surely, since",
-      "that",
-      "yea, indeed",
-      "when (of time)",
-      "when, if, though (with a concessive force)",
-      "because, since (causal connection)",
-      "but (after negative)",
-      "that if, for if, indeed if, for though, but if",
-      "but rather, but",
-      "except that",
-      "only, nevertheless",
-      "surely",
-      "that is",
-      "but if",
-      "for though",
-      "forasmuch as, for therefore"
-    ],
-    "strongs_definition": [
-      "כִּי kîy, kee",
-      "a primitive particle (the full form of the prepositional prefix) indicating causal relations of all kinds, antecedent or consequent",
-      "(by implication) very widely used as a relative conjunction or adverb (as below)",
-      "often largely modified by other particles annexed:—and, (forasmuch, inasmuch, where-) as, assured(-ly), but, certainly, doubtless, else, even, except, for, how, (because, in, so, than) that, nevertheless, now, rightly, seeing, since, surely, then, therefore, (al-) though, till, truly, until, when, whether, while, whom, yea, yet."
     ]
   },
   {
@@ -243098,46 +240401,6 @@
     ]
   },
   {
-    "concord_id": "H3602",
-    "original_word": "כָּכָה",
-    "transliteration": "kāḵâ",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "thus",
-        "count": null
-      },
-      {
-        "translation": "so",
-        "count": null
-      },
-      {
-        "translation": "after",
-        "count": null
-      },
-      {
-        "translation": "this",
-        "count": null
-      },
-      {
-        "translation": "even so",
-        "count": null
-      },
-      {
-        "translation": "in such a case",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "like this, thus"
-    ],
-    "strongs_definition": [
-      "כָּכָה kâkâh, kaw'-kaw",
-      "from H3541",
-      "just so, referring to the previous or following context:—after that (this) manner, this matter, (even) so, in such a case, thus."
-    ]
-  },
-  {
     "concord_id": "H3603",
     "original_word": "כִּכָּר",
     "transliteration": "kikār",
@@ -243203,51 +240466,6 @@
     ]
   },
   {
-    "concord_id": "H3605",
-    "original_word": "כֹּל",
-    "transliteration": "kōl",
-    "part_of_speech": "masculine noun",
-    "english_translations": [
-      {
-        "translation": "every thing",
-        "count": null
-      },
-      {
-        "translation": "all",
-        "count": null
-      },
-      {
-        "translation": "whosoever",
-        "count": null
-      },
-      {
-        "translation": "whatsoever",
-        "count": null
-      },
-      {
-        "translation": "nothing",
-        "count": null
-      },
-      {
-        "translation": "yet",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "all, the whole",
-      "all, the whole of",
-      "any, each, every, anything",
-      "totality, everything"
-    ],
-    "strongs_definition": [
-      "כֹּל kôl, kole",
-      "or (Jeremiah 33:8) כּוֹל kôwl",
-      "from H3634",
-      "properly, the whole",
-      "hence, all, any or every (in the singular only, but often in a plural sense):—(in) all (manner, (ye)), altogether, any (manner), enough, every (one, place, thing), howsoever, as many as, (no-) thing, ought, whatsoever, (the) whole, whoso(-ever)."
-    ]
-  },
-  {
     "concord_id": "H3606",
     "original_word": "כֹּל",
     "transliteration": "kōl",
@@ -243267,26 +240485,22 @@
       },
       {
         "translation": "as",
-        "count": 4
+        "count": 6
       },
       {
         "translation": "every",
         "count": 4
       },
       {
-        "translation": "because (with H6903)",
+        "translation": "because",
         "count": 4
-      },
-      {
-        "translation": "as (with H6903)",
-        "count": 2
       },
       {
         "translation": "no",
         "count": 2
       },
       {
-        "translation": "whosoever (with H606)",
+        "translation": "whosoever",
         "count": 2
       },
       {
@@ -243930,7 +241144,7 @@
         "count": 21
       },
       {
-        "translation": "armourbearer (with H5375)",
+        "translation": "armourbearer",
         "count": 18
       },
       {
@@ -243987,7 +241201,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "prison (with H1004)",
+        "translation": "prison",
         "count": 2
       }
     ],
@@ -244446,44 +241660,6 @@
     ]
   },
   {
-    "concord_id": "H3644",
-    "original_word": "כְּמוֹ",
-    "transliteration": "kᵊmô",
-    "part_of_speech": "adverb, conjunction",
-    "english_translations": [
-      {
-        "translation": "and when",
-        "count": null
-      },
-      {
-        "translation": "as thyself",
-        "count": null
-      },
-      {
-        "translation": "like me",
-        "count": null
-      },
-      {
-        "translation": "according to it",
-        "count": null
-      },
-      {
-        "translation": "worth",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "like, as, the like of which",
-      "when, according as, as it were"
-    ],
-    "strongs_definition": [
-      "כְּמוֹ kᵉmôw, kem-o'",
-      "or כָּמוֹ kâmôw",
-      "a form of the prefix k, but used separately [compare H3651]",
-      "as, thus, so:—according to, (such) as (it were, well as), in comparison of, like (as, to, unto), thus, when, worth."
-    ]
-  },
-  {
     "concord_id": "H3645",
     "original_word": "כְּמוֹשׁ",
     "transliteration": "kᵊmôš",
@@ -244624,94 +241800,6 @@
       "כִּמְרִיר kimrîyr, kim-reer'",
       "redupl. from H3648",
       "obscuration (as if from shrinkage of light), i.e. an eclipse (only in plural):—blackness."
-    ]
-  },
-  {
-    "concord_id": "H3651",
-    "original_word": "כֵּן",
-    "transliteration": "kēn",
-    "part_of_speech": "adjective, adverb",
-    "english_translations": [
-      {
-        "translation": "so",
-        "count": null
-      },
-      {
-        "translation": "thus",
-        "count": null
-      },
-      {
-        "translation": "like manner",
-        "count": null
-      },
-      {
-        "translation": "well",
-        "count": null
-      },
-      {
-        "translation": "such thing",
-        "count": null
-      },
-      {
-        "translation": "howbeit",
-        "count": null
-      },
-      {
-        "translation": "state",
-        "count": null
-      },
-      {
-        "translation": "after that",
-        "count": null
-      },
-      {
-        "translation": "following",
-        "count": null
-      },
-      {
-        "translation": "after this",
-        "count": null
-      },
-      {
-        "translation": "therefore",
-        "count": null
-      },
-      {
-        "translation": "wherefore",
-        "count": null
-      },
-      {
-        "translation": "surely",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "so, therefore, thus",
-      "thus, so",
-      "just so",
-      "therefore",
-      "so...as (paired with adverb)",
-      "then",
-      "forasmuch as (in phrase)",
-      "(with preposition)",
-      "therefore, this being so (specific)",
-      "hitherto",
-      "therefore, on this ground (general)",
-      "afterwards",
-      "in such case",
-      "right, just, honest, true, veritable",
-      "right, just, honest",
-      "correct",
-      "true, veritable",
-      "true!, right!, correct! (in assent)"
-    ],
-    "strongs_definition": [
-      "כֵּן kên, kane",
-      "from H3559",
-      "properly, set upright",
-      "hence (figuratively as adjective) just",
-      "but usually (as adverb or conjunction) rightly or so (in various applications to manner, time and relation",
-      "often with other particles):— after that (this, -ward, -wards), as... as, (for-) asmuch as yet, be (for which) cause, following, howbeit, in (the) like (manner, -wise), × the more, right, (even) so, state, straightway, such (thing), surely, there (where) -fore, this, thus, true, well, × you."
     ]
   },
   {
@@ -244949,7 +242037,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "vineyard (with H3657)",
+        "translation": "vineyard",
         "count": 1
       }
     ],
@@ -245386,7 +242474,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "sworn (with H3027)",
+        "translation": "sworn",
         "count": 1
       }
     ],
@@ -246332,7 +243420,7 @@
         "count": 1
       },
       {
-        "translation": "breadth (with H4096)",
+        "translation": "breadth",
         "count": 1
       },
       {
@@ -248225,7 +245313,7 @@
         "count": 2
       },
       {
-        "translation": "bereave (with H7921)",
+        "translation": "bereave",
         "count": 1
       },
       {
@@ -248982,67 +246070,6 @@
     ]
   },
   {
-    "concord_id": "H3808",
-    "original_word": "לֹא",
-    "transliteration": "lō'",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "not",
-        "count": null
-      },
-      {
-        "translation": "no",
-        "count": null
-      },
-      {
-        "translation": "none",
-        "count": null
-      },
-      {
-        "translation": "nay",
-        "count": null
-      },
-      {
-        "translation": "never",
-        "count": null
-      },
-      {
-        "translation": "neither",
-        "count": null
-      },
-      {
-        "translation": "ere",
-        "count": null
-      },
-      {
-        "translation": "otherwise",
-        "count": null
-      },
-      {
-        "translation": "before",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "not, no",
-      "not (with verb - absolute prohibition)",
-      "not (with modifier - negation)",
-      "nothing (subst)",
-      "without (with particle)",
-      "before (of time)"
-    ],
-    "strongs_definition": [
-      "לֹא lôʼ, lo",
-      "or לוֹא lôwʼ",
-      "or לֹה lôh",
-      "(Deuteronomy 3:11), a primitive particle",
-      "+ not (the simple or abstract negation)",
-      "by implication, no",
-      "often used with other particles:—× before, + or else, ere, + except, ig(-norant), much, less, nay, neither, never, no((-ne), -r, (-thing)), (× as though...,(can-), for) not (out of), of nought, otherwise, out of, + surely, + as truly as, + of a truth, + verily, for want, + whether, without."
-    ]
-  },
-  {
     "concord_id": "H3809",
     "original_word": "לָא",
     "transliteration": "lā'",
@@ -249054,7 +246081,7 @@
       },
       {
         "translation": "no",
-        "count": 9
+        "count": 10
       },
       {
         "translation": "nor",
@@ -249073,7 +246100,7 @@
         "count": 3
       },
       {
-        "translation": "cannot (with H3202)",
+        "translation": "cannot",
         "count": 1
       },
       {
@@ -249081,11 +246108,7 @@
         "count": 1
       },
       {
-        "translation": "never (with H5957)",
-        "count": 1
-      },
-      {
-        "translation": "no (with H3606)",
+        "translation": "never",
         "count": 1
       },
       {
@@ -249399,16 +246422,12 @@
         "count": 2
       },
       {
-        "translation": "stouthearted (with H47)",
+        "translation": "stouthearted",
         "count": 2
       },
       {
-        "translation": "care (with H7760)",
+        "translation": "care",
         "count": 2
-      },
-      {
-        "translation": "misc 21",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -249524,7 +246543,7 @@
         "count": 231
       },
       {
-        "translation": "consider (with H7760)",
+        "translation": "consider",
         "count": 5
       },
       {
@@ -250743,11 +247762,7 @@
       },
       {
         "translation": "lender",
-        "count": 1
-      },
-      {
-        "translation": "lender (with H376)",
-        "count": 1
+        "count": 2
       }
     ],
     "outline_definitions": [
@@ -251665,20 +248680,12 @@
         "count": 18
       },
       {
-        "translation": "shewbread (with H6440)",
-        "count": 5
+        "translation": "shewbread",
+        "count": 10
       },
       {
         "translation": "loaves",
         "count": 5
-      },
-      {
-        "translation": "shewbread (with H4635)",
-        "count": 3
-      },
-      {
-        "translation": "shewbread",
-        "count": 2
       },
       {
         "translation": "victuals",
@@ -252125,35 +249132,19 @@
     "english_translations": [
       {
         "translation": "night",
-        "count": 205
+        "count": 207
       },
       {
         "translation": "nights",
         "count": 15
       },
       {
-        "translation": "midnight (with H2677)",
-        "count": 4
+        "translation": "midnight",
+        "count": 8
       },
       {
         "translation": "season",
         "count": 3
-      },
-      {
-        "translation": "midnight (with H2676)",
-        "count": 2
-      },
-      {
-        "translation": "night (with H1121)",
-        "count": 2
-      },
-      {
-        "translation": "midnight",
-        "count": 1
-      },
-      {
-        "translation": "midnight (with H8432)",
-        "count": 1
       }
     ],
     "outline_definitions": [
@@ -252427,7 +249418,7 @@
         "count": 1
       },
       {
-        "translation": "unaccustomed (with H3808)",
+        "translation": "unaccustomed",
         "count": 1
       }
     ],
@@ -253310,7 +250301,7 @@
         "count": 1
       },
       {
-        "translation": "speaker (with H376)",
+        "translation": "speaker",
         "count": 1
       },
       {
@@ -253560,7 +250551,7 @@
       },
       {
         "translation": "exceeding",
-        "count": 18
+        "count": 24
       },
       {
         "translation": "great",
@@ -253568,19 +250559,11 @@
       },
       {
         "translation": "exceedingly",
-        "count": 11
+        "count": 16
       },
       {
         "translation": "much",
         "count": 10
-      },
-      {
-        "translation": "exceeding (with H3966)",
-        "count": 6
-      },
-      {
-        "translation": "exceedingly (with H3966)",
-        "count": 5
       },
       {
         "translation": "diligently",
@@ -253632,7 +250615,7 @@
         "count": 571
       },
       {
-        "translation": "eleven hundred (with H505)",
+        "translation": "eleven hundred",
         "count": 3
       },
       {
@@ -253644,7 +250627,7 @@
         "count": 2
       },
       {
-        "translation": "sixscore (with H6242)",
+        "translation": "sixscore",
         "count": 1
       },
       {
@@ -255518,7 +252501,7 @@
         "count": 1
       },
       {
-        "translation": "scales (with H650)",
+        "translation": "scales",
         "count": 1
       }
     ],
@@ -255872,7 +252855,7 @@
     "english_translations": [
       {
         "translation": "wilderness",
-        "count": 255
+        "count": 256
       },
       {
         "translation": "desert",
@@ -255884,10 +252867,6 @@
       },
       {
         "translation": "speech",
-        "count": 1
-      },
-      {
-        "translation": "wilderness (with H776)",
         "count": 1
       }
     ],
@@ -256205,36 +253184,6 @@
       "מָדוֹן Mâdôwn, maw-dohn'",
       "the same as H4067",
       "Madon, a place in Palestine:—Madon."
-    ]
-  },
-  {
-    "concord_id": "H4069",
-    "original_word": "מַדּוּעַ",
-    "transliteration": "madûaʿ",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "wherefore",
-        "count": null
-      },
-      {
-        "translation": "why",
-        "count": null
-      },
-      {
-        "translation": "how",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "why?, on what account?, wherefore?"
-    ],
-    "strongs_definition": [
-      "מַדּוּעַ maddûwaʻ, mad-doo'-ah",
-      "or מַדֻּעַ madduaʻ",
-      "from H4100 and the passive participle of H3045",
-      "what (is) known?",
-      "i.e. (by implication) (adverbially) why?:—how, wherefore, why."
     ]
   },
   {
@@ -256914,78 +253863,6 @@
       "מְדָתָא Mᵉdâthâʼ, med-aw-thaw'",
       "of Persian origin",
       "Medatha, the father of Haman:—Hammedatha (including the article)."
-    ]
-  },
-  {
-    "concord_id": "H4100",
-    "original_word": "מָה",
-    "transliteration": "mâ",
-    "part_of_speech": "indefinite pronoun, interrogative pronoun",
-    "english_translations": [
-      {
-        "translation": "what",
-        "count": null
-      },
-      {
-        "translation": "how",
-        "count": null
-      },
-      {
-        "translation": "why",
-        "count": null
-      },
-      {
-        "translation": "whereby",
-        "count": null
-      },
-      {
-        "translation": "wherein",
-        "count": null
-      },
-      {
-        "translation": "how long",
-        "count": null
-      },
-      {
-        "translation": "how oft",
-        "count": null
-      },
-      {
-        "translation": "to what end",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "what, how, of what kind",
-      "(interrogative)",
-      "what?",
-      "of what kind",
-      "what? (rhetorical)",
-      "whatsoever, whatever, what",
-      "(adverb)",
-      "how, how now",
-      "why",
-      "how! (exclamation)",
-      "(with preposition)",
-      "wherein?, whereby?, wherewith?, by what means?",
-      "because of what?",
-      "the like of what?",
-      "how much?, how many?, how often?",
-      "for how long?",
-      "for what reason?, why?, to what purpose?",
-      "until when?, how long?, upon what?, wherefore?",
-      "anything, aught, what may"
-    ],
-    "strongs_definition": [
-      "מָה mâh, maw",
-      "or מַה mah",
-      "or מָ mâ",
-      "or מַ ma",
-      "also מֶה meh",
-      "a primitive particle",
-      "properly, interrogative what? (including how? why? when?)",
-      "but also exclamation, what! (including how!), or indefinitely what (including whatever, and even relatively, that which)",
-      "often used with prefixes in various adverbial or conjunctive senses:—how (long, oft, (-soever)), (no-) thing, what (end, good, purpose, thing), whereby(-fore, -in, -to, -with), (for) why."
     ]
   },
   {
@@ -258099,38 +254976,30 @@
     "english_translations": [
       {
         "translation": "against",
-        "count": 21
+        "count": 22
       },
       {
         "translation": "toward",
         "count": 3
       },
       {
-        "translation": "forefront (with H6440)",
-        "count": 3
+        "translation": "forefront",
+        "count": 4
       },
       {
         "translation": "before",
         "count": 2
       },
       {
-        "translation": "before it (with H6440)",
+        "translation": "before it",
         "count": 2
-      },
-      {
-        "translation": "against (with H6440)",
-        "count": 1
-      },
-      {
-        "translation": "forefront",
-        "count": 1
       },
       {
         "translation": "from",
         "count": 1
       },
       {
-        "translation": "God-ward (with H430)",
+        "translation": "God-ward",
         "count": 1
       },
       {
@@ -258843,7 +255712,7 @@
         "count": 2
       },
       {
-        "translation": "watersprings (with H4325)",
+        "translation": "watersprings",
         "count": 2
       },
       {
@@ -259792,7 +256661,7 @@
         "count": 1
       },
       {
-        "translation": "Muthlabben (with H1121)",
+        "translation": "Muthlabben",
         "count": 1
       }
     ],
@@ -260405,8 +257274,8 @@
         "count": 20
       },
       {
-        "translation": "sunrising (with H8121)",
-        "count": 9
+        "translation": "sunrising",
+        "count": 10
       },
       {
         "translation": "rising",
@@ -260418,10 +257287,6 @@
       },
       {
         "translation": "east end",
-        "count": 1
-      },
-      {
-        "translation": "sunrising",
         "count": 1
       }
     ],
@@ -260704,15 +257569,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(blot",
-        "count": null
-      },
-      {
-        "translation": "put",
-        "count": null
-      },
-      {
-        "translation": "etc)...out",
+        "translation": "(blot, put, etc)...out",
         "count": 17
       },
       {
@@ -261976,7 +258833,7 @@
         "count": 1
       },
       {
-        "translation": "midday (with H3117)",
+        "translation": "midday",
         "count": 1
       }
     ],
@@ -262450,7 +259307,7 @@
     "english_translations": [
       {
         "translation": "tribe",
-        "count": 182
+        "count": 183
       },
       {
         "translation": "rod",
@@ -262462,10 +259319,6 @@
       },
       {
         "translation": "staves",
-        "count": 1
-      },
-      {
-        "translation": "tribe (with H4294)",
         "count": 1
       }
     ],
@@ -262549,7 +259402,7 @@
         "count": 26
       },
       {
-        "translation": "bedchamber (with H2315)",
+        "translation": "bedchamber",
         "count": 2
       },
       {
@@ -262878,47 +259731,6 @@
       "from H4305",
       "rainy",
       "Matri, an Israelite:—Matri."
-    ]
-  },
-  {
-    "concord_id": "H4310",
-    "original_word": "מִי",
-    "transliteration": "mî",
-    "part_of_speech": "interrogative pronoun",
-    "english_translations": [
-      {
-        "translation": "who",
-        "count": null
-      },
-      {
-        "translation": "any",
-        "count": null
-      },
-      {
-        "translation": "whose",
-        "count": null
-      },
-      {
-        "translation": "what",
-        "count": null
-      },
-      {
-        "translation": "if any",
-        "count": null
-      },
-      {
-        "translation": "whom",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "who?, whose?, whom?, would that, whoever, whosoever"
-    ],
-    "strongs_definition": [
-      "מִי mîy, me",
-      "an interrogative pronoun of persons, as H4100 is of things, who? (occasionally, by a peculiar idiom, of things)",
-      "also (indefinitely) whoever",
-      "often used in oblique construction with prefix or suffix:—any (man), × he, × him, O that! what, which, who(-m, -se, -soever), would to God."
     ]
   },
   {
@@ -263284,7 +260096,7 @@
         "count": 2
       },
       {
-        "translation": "waters (with H6440)",
+        "translation": "waters",
         "count": 2
       },
       {
@@ -263296,7 +260108,7 @@
         "count": 1
       },
       {
-        "translation": "watercourse (with H4161)",
+        "translation": "watercourse",
         "count": 1
       },
       {
@@ -264150,7 +260962,7 @@
         "count": 2
       },
       {
-        "translation": "sheepfold (with H6629)",
+        "translation": "sheepfold",
         "count": 1
       }
     ],
@@ -264684,7 +261496,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "saltpit (with H4417)",
+        "translation": "saltpit",
         "count": 1
       }
     ],
@@ -265128,18 +261940,14 @@
       },
       {
         "translation": "handful",
-        "count": 2
+        "count": 3
       },
       {
         "translation": "multitude",
         "count": 2
       },
       {
-        "translation": "handful (with H7062)",
-        "count": 1
-      },
-      {
-        "translation": "handfuls (with H2651)",
+        "translation": "handfuls",
         "count": 1
       }
     ],
@@ -265307,7 +262115,7 @@
         "count": 12
       },
       {
-        "translation": "workmen (with H6213)",
+        "translation": "workmen",
         "count": 7
       },
       {
@@ -265491,7 +262299,7 @@
         "count": 2
       },
       {
-        "translation": "answer (with H7725)",
+        "translation": "answer",
         "count": 1
       },
       {
@@ -265835,7 +262643,7 @@
         "count": 27
       },
       {
-        "translation": "saltpits (with H4379)",
+        "translation": "saltpits",
         "count": 1
       }
     ],
@@ -265924,7 +262732,7 @@
     "english_translations": [
       {
         "translation": "war",
-        "count": 158
+        "count": 159
       },
       {
         "translation": "battle",
@@ -265935,19 +262743,15 @@
         "count": 5
       },
       {
-        "translation": "warriors (with H6213)",
+        "translation": "warriors",
         "count": 2
       },
       {
-        "translation": "fighting (with H6213)",
+        "translation": "fighting",
         "count": 1
       },
       {
-        "translation": "war (with H376)",
-        "count": 1
-      },
-      {
-        "translation": "wars (with H376)",
+        "translation": "wars",
         "count": 1
       }
     ],
@@ -267347,15 +264151,11 @@
     "english_translations": [
       {
         "translation": "dominion",
-        "count": 10
+        "count": 11
       },
       {
         "translation": "rule",
         "count": 4
-      },
-      {
-        "translation": "dominion (with H3027)",
-        "count": 1
       },
       {
         "translation": "government",
@@ -267471,74 +264271,6 @@
       "מָן mân, mawn",
       "(Aramaic) from H4101",
       "who or what (properly, interrogatively, hence, also indefinitely and relatively):—what, who(-msoever, -so)."
-    ]
-  },
-  {
-    "concord_id": "H4480",
-    "original_word": "מִן",
-    "transliteration": "min",
-    "part_of_speech": "conjunction, preposition",
-    "english_translations": [
-      {
-        "translation": "among",
-        "count": null
-      },
-      {
-        "translation": "with",
-        "count": null
-      },
-      {
-        "translation": "from",
-        "count": null
-      },
-      {
-        "translation": "that not",
-        "count": null
-      },
-      {
-        "translation": "since",
-        "count": null
-      },
-      {
-        "translation": "after",
-        "count": null
-      },
-      {
-        "translation": "at",
-        "count": null
-      },
-      {
-        "translation": "by",
-        "count": null
-      },
-      {
-        "translation": "whether",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "from, out of, on account of, off, on the side of, since, above, than, so that not, more than",
-      "from (expressing separation), off, on the side of",
-      "out of",
-      "(with verbs of proceeding, removing, expelling)",
-      "(of material from which something is made)",
-      "(of source or origin)",
-      "out of, some of, from (partitively)",
-      "from, since, after (of time)",
-      "than, more than (in comparison)",
-      "from...even to, both...and, either...or",
-      "than, more than, too much for (in comparisons)",
-      "from, on account of, through, because (with infinitive)",
-      "that"
-    ],
-    "strongs_definition": [
-      "מִן min, min",
-      "or מִנִּי minnîy",
-      "or מִנֵּי minnêy",
-      "(constructive plural) (Isaiah 30:11)",
-      "for H4482",
-      "properly, a part of",
-      "hence (prepositionally), from or out of in many senses:—above, after, among, at, because of, by (reason of), from (among), in, × neither, × nor, (out) of, over, since, × then, through, × whether, with."
     ]
   },
   {
@@ -268847,10 +265579,6 @@
       {
         "translation": "consume away",
         "count": 1
-      },
-      {
-        "translation": "water",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -269561,7 +266289,7 @@
       },
       {
         "translation": "innumerable",
-        "count": 3
+        "count": 4
       },
       {
         "translation": "sum",
@@ -269576,15 +266304,11 @@
         "count": 1
       },
       {
-        "translation": "abundance (with H369)",
+        "translation": "abundance",
         "count": 1
       },
       {
         "translation": "infinite",
-        "count": 1
-      },
-      {
-        "translation": "innumerable (with H369)",
         "count": 1
       },
       {
@@ -269923,7 +266647,7 @@
         "count": 1
       },
       {
-        "translation": "wayside (with H3027)",
+        "translation": "wayside",
         "count": 1
       }
     ],
@@ -270845,7 +267569,7 @@
         "count": 1
       },
       {
-        "translation": "Syriamaachah (with H758)",
+        "translation": "Syriamaachah",
         "count": 1
       }
     ],
@@ -271029,7 +267753,7 @@
         "count": 1
       },
       {
-        "translation": "overturned (with H2015)",
+        "translation": "overturned",
         "count": 1
       },
       {
@@ -271037,7 +267761,7 @@
         "count": 1
       },
       {
-        "translation": "up (with H935)",
+        "translation": "up",
         "count": 1
       }
     ],
@@ -271353,55 +268077,6 @@
       "מַעֲמָק maʻămâq, mah-am-awk'",
       "from H6009",
       "a deep:—deep, depth."
-    ]
-  },
-  {
-    "concord_id": "H4616",
-    "original_word": "מַעַן",
-    "transliteration": "maʿan",
-    "part_of_speech": "preposition, substantive",
-    "english_translations": [
-      {
-        "translation": "that",
-        "count": null
-      },
-      {
-        "translation": "for",
-        "count": null
-      },
-      {
-        "translation": "to",
-        "count": null
-      },
-      {
-        "translation": "to the end",
-        "count": null
-      },
-      {
-        "translation": "because of",
-        "count": null
-      },
-      {
-        "translation": "lest",
-        "count": null
-      },
-      {
-        "translation": "to the intent",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "purpose, intent",
-      "for the sake of",
-      "in view of, on account of",
-      "for the purpose of, to the intent that, in order to",
-      "to the end that"
-    ],
-    "strongs_definition": [
-      "מַעַן maʻan, mah'-an",
-      "from H6030",
-      "properly, heed, i.e. purpose",
-      "used only adverbially, on account of (as a motive or an aim), teleologically, in order that:—because of, to the end (intent) that, for (to, ... 's sake), + lest, that, to."
     ]
   },
   {
@@ -271845,12 +268520,8 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "shewbread (with H3899)",
-        "count": 5
-      },
-      {
         "translation": "shewbread",
-        "count": 2
+        "count": 7
       },
       {
         "translation": "row",
@@ -271939,7 +268610,7 @@
         "count": 189
       },
       {
-        "translation": "needlework (with H7551)",
+        "translation": "needlework",
         "count": 5
       },
       {
@@ -273019,11 +269690,7 @@
         "count": 1
       },
       {
-        "translation": "fort",
-        "count": null
-      },
-      {
-        "translation": "munition",
+        "translation": "fort, munition",
         "count": 1
       }
     ],
@@ -273233,7 +269900,7 @@
       },
       {
         "translation": "strong hold",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "castle",
@@ -273249,10 +269916,6 @@
       },
       {
         "translation": "hunted",
-        "count": 1
-      },
-      {
-        "translation": "strong hold",
         "count": 1
       },
       {
@@ -273443,14 +270106,10 @@
       },
       {
         "translation": "besieged",
-        "count": 2
+        "count": 4
       },
       {
         "translation": "strong",
-        "count": 2
-      },
-      {
-        "translation": "besieged (with H935)",
         "count": 2
       },
       {
@@ -273987,11 +270646,7 @@
     "english_translations": [
       {
         "translation": "Egyptian",
-        "count": 25
-      },
-      {
-        "translation": "Egyptian (with H376)",
-        "count": 3
+        "count": 28
       },
       {
         "translation": "Egypt",
@@ -274033,7 +270688,7 @@
         "count": 4
       },
       {
-        "translation": "Egyptians (with H1121)",
+        "translation": "Egyptians",
         "count": 1
       }
     ],
@@ -274511,7 +271166,7 @@
         "count": 2
       },
       {
-        "translation": "handstave (with H3027)",
+        "translation": "handstave",
         "count": 1
       }
     ],
@@ -275269,7 +271924,7 @@
         "count": 4
       },
       {
-        "translation": "fair (with H2896)",
+        "translation": "fair",
         "count": 2
       },
       {
@@ -276549,7 +273204,7 @@
         "count": 5
       },
       {
-        "translation": "Meribahkadesh (with H6946)",
+        "translation": "Meribahkadesh",
         "count": 1
       },
       {
@@ -277146,7 +273801,7 @@
         "count": 3
       },
       {
-        "translation": "incurable (with H369)",
+        "translation": "incurable",
         "count": 1
       },
       {
@@ -277431,7 +274086,7 @@
     "english_translations": [
       {
         "translation": "bitterness",
-        "count": 3
+        "count": 4
       },
       {
         "translation": "bitter",
@@ -277452,10 +274107,6 @@
       {
         "translation": "vexed",
         "count": 2
-      },
-      {
-        "translation": "bitterness (with H4751)",
-        "count": 1
       },
       {
         "translation": "grieved him",
@@ -278259,7 +274910,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "creditor (with H1167)",
+        "translation": "creditor",
         "count": 1
       }
     ],
@@ -279024,7 +275675,7 @@
         "count": 34
       },
       {
-        "translation": "bedchamber (with H2315)",
+        "translation": "bedchamber",
         "count": 4
       },
       {
@@ -280708,11 +277359,7 @@
       },
       {
         "translation": "few",
-        "count": 2
-      },
-      {
-        "translation": "few (with H4557)",
-        "count": 1
+        "count": 3
       },
       {
         "translation": "friends",
@@ -280910,33 +277557,6 @@
       "מָתַח mâthach, maw-thakh'",
       "a primitive root",
       "to stretch out:—spread out."
-    ]
-  },
-  {
-    "concord_id": "H4970",
-    "original_word": "מָתַי",
-    "transliteration": "māṯay",
-    "part_of_speech": "interrogative adverb",
-    "english_translations": [
-      {
-        "translation": "when",
-        "count": null
-      },
-      {
-        "translation": "long",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "when?",
-      "with prep",
-      "against when?, until when?, how long?, after how long?"
-    ],
-    "strongs_definition": [
-      "מָתַי mâthay, maw-thah'ee",
-      "from an unused root meaning to extend",
-      "properly, extent (of time)",
-      "but used only adverbially (especially with other particle prefixes), when (either relative or interrogative):—long, when."
     ]
   },
   {
@@ -281487,44 +278107,6 @@
       "from H4991 and H3050",
       "gift of Jah",
       "Mattithjah, the name of four Israelites:—Mattithiah."
-    ]
-  },
-  {
-    "concord_id": "H4994",
-    "original_word": "נָא",
-    "transliteration": "nā'",
-    "part_of_speech": "particle",
-    "english_translations": [
-      {
-        "translation": "now",
-        "count": null
-      },
-      {
-        "translation": "I beseech ...",
-        "count": null
-      },
-      {
-        "translation": "I pray ...",
-        "count": null
-      },
-      {
-        "translation": "Oh",
-        "count": null
-      },
-      {
-        "translation": "go to",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "I (we) pray, now, please",
-      "used in entreaty or exhortation"
-    ],
-    "strongs_definition": [
-      "נָא nâʼ, naw",
-      "a primitive particle of incitement and entreaty, which may usually be rendered",
-      "'I pray', 'now', or 'then'",
-      "added mostly to verbs (in the Imperative or Future), or to interjections, occasionally to an adverb or conjunction:—I beseech (pray) thee (you), go to, now, oh."
     ]
   },
   {
@@ -282445,7 +279027,7 @@
     "english_translations": [
       {
         "translation": "prophet",
-        "count": 312
+        "count": 313
       },
       {
         "translation": "prophecy",
@@ -282453,10 +279035,6 @@
       },
       {
         "translation": "them that prophesy",
-        "count": 1
-      },
-      {
-        "translation": "prophet (with H376)",
         "count": 1
       },
       {
@@ -282578,7 +279156,7 @@
       },
       {
         "translation": "surely",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "dishonoureth",
@@ -282606,10 +279184,6 @@
       },
       {
         "translation": "fall off",
-        "count": 1
-      },
-      {
-        "translation": "surely",
         "count": 1
       },
       {
@@ -283074,54 +279648,6 @@
     ]
   },
   {
-    "concord_id": "H5048",
-    "original_word": "נֶגֶד",
-    "transliteration": "neḡeḏ",
-    "part_of_speech": "adjective, adverb (with a preposition), substantive",
-    "english_translations": [
-      {
-        "translation": "before",
-        "count": null
-      },
-      {
-        "translation": "against",
-        "count": null
-      },
-      {
-        "translation": "in the presence",
-        "count": null
-      },
-      {
-        "translation": "about",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "what is conspicuous, what is in front of",
-      "in front of, straight forward, before, in sight of",
-      "in front of oneself, straightforward",
-      "before your face, in your view or purpose",
-      "what is in front of, corresponding to",
-      "in front of, before",
-      "in the sight or presence of",
-      "parallel to",
-      "over, for",
-      "in front, opposite",
-      "at a distance",
-      "from the front of, away from",
-      "from before the eyes of, opposite to, at a distance from",
-      "from before, in front of",
-      "as far as the front of"
-    ],
-    "strongs_definition": [
-      "נֶגֶד neged, neh'-ghed",
-      "from H5046",
-      "a front, i.e. part opposite",
-      "specifically a counterpart, or mate",
-      "usually (adverbial, especially with preposition) over against or before:—about, (over) against, × aloof, × far (off), × from, over, presence, × other side, sight, × to view."
-    ]
-  },
-  {
     "concord_id": "H5049",
     "original_word": "נֶגֶד",
     "transliteration": "neḡeḏ",
@@ -283516,10 +280042,6 @@
       {
         "translation": "laid",
         "count": 1
-      },
-      {
-        "translation": "get up",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -283801,15 +280323,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(come",
-        "count": null
-      },
-      {
-        "translation": "draw",
-        "count": null
-      },
-      {
-        "translation": "etc)..near",
+        "translation": "(come, draw, etc)..near",
         "count": 55
       },
       {
@@ -283817,15 +280331,7 @@
         "count": 14
       },
       {
-        "translation": "(come",
-        "count": null
-      },
-      {
-        "translation": "draw",
-        "count": null
-      },
-      {
-        "translation": "etc)..nigh",
+        "translation": "(come, draw, etc)..nigh",
         "count": 12
       },
       {
@@ -283913,14 +280419,10 @@
       },
       {
         "translation": "willing",
-        "count": 2
+        "count": 3
       },
       {
         "translation": "offered",
-        "count": 1
-      },
-      {
-        "translation": "willing",
         "count": 1
       },
       {
@@ -284672,11 +281174,7 @@
         "count": 10
       },
       {
-        "translation": "(carry",
-        "count": null
-      },
-      {
-        "translation": "lead)...away",
+        "translation": "(carry, lead)...away",
         "count": 7
       },
       {
@@ -285079,7 +281577,7 @@
         "count": 2
       },
       {
-        "translation": "Aramnaharaim (with H763)",
+        "translation": "Aramnaharaim",
         "count": 1
       },
       {
@@ -289032,12 +285530,8 @@
         "count": 17
       },
       {
-        "translation": "stranger (with H1121)",
-        "count": 10
-      },
-      {
         "translation": "stranger",
-        "count": 7
+        "count": 17
       },
       {
         "translation": "alien",
@@ -289064,7 +285558,7 @@
     "english_translations": [
       {
         "translation": "stranger",
-        "count": 18
+        "count": 19
       },
       {
         "translation": "strange",
@@ -289084,10 +285578,6 @@
       },
       {
         "translation": "outlandish",
-        "count": 1
-      },
-      {
-        "translation": "stranger (with H376)",
         "count": 1
       }
     ],
@@ -290133,7 +286623,7 @@
         "count": 1
       },
       {
-        "translation": "shoelatchet (with H8288)",
+        "translation": "shoelatchet",
         "count": 1
       }
     ],
@@ -290470,7 +286960,7 @@
       },
       {
         "translation": "young",
-        "count": 15
+        "count": 16
       },
       {
         "translation": "children",
@@ -290486,10 +286976,6 @@
       },
       {
         "translation": "boys",
-        "count": 1
-      },
-      {
-        "translation": "young",
         "count": 1
       }
     ],
@@ -291074,10 +287560,6 @@
       {
         "translation": "fall",
         "count": 3
-      },
-      {
-        "translation": "have occasion",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -291789,7 +288271,7 @@
       },
       {
         "translation": "never",
-        "count": 4
+        "count": 5
       },
       {
         "translation": "perpetual",
@@ -291821,10 +288303,6 @@
       },
       {
         "translation": "evermore",
-        "count": 1
-      },
-      {
-        "translation": "never (with H3808)",
         "count": 1
       }
     ],
@@ -292130,7 +288608,7 @@
         "count": 1
       },
       {
-        "translation": "observe (with H7521)",
+        "translation": "observe",
         "count": 1
       },
       {
@@ -292766,7 +289244,7 @@
         "count": 18
       },
       {
-        "translation": "avenge (with H5414)",
+        "translation": "avenge",
         "count": 3
       },
       {
@@ -292774,7 +289252,7 @@
         "count": 3
       },
       {
-        "translation": "Avenge (with H5358)",
+        "translation": "Avenge",
         "count": 1
       },
       {
@@ -292782,7 +289260,7 @@
         "count": 1
       },
       {
-        "translation": "take vengeance for thee (with H5358)",
+        "translation": "take vengeance for thee",
         "count": 1
       }
     ],
@@ -293181,15 +289659,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(bare",
-        "count": null
-      },
-      {
-        "translation": "lift",
-        "count": null
-      },
-      {
-        "translation": "etc...) up",
+        "translation": "(bare, lift, etc...) up",
         "count": 219
       },
       {
@@ -293209,11 +289679,7 @@
         "count": 30
       },
       {
-        "translation": "(take",
-        "count": null
-      },
-      {
-        "translation": "carry)..away",
+        "translation": "(take, carry)..away",
         "count": 22
       },
       {
@@ -293445,11 +289911,7 @@
       },
       {
         "translation": "get",
-        "count": 3
-      },
-      {
-        "translation": "get (with H3027)",
-        "count": 3
+        "count": 6
       },
       {
         "translation": "attain",
@@ -293464,16 +289926,12 @@
         "count": 2
       },
       {
-        "translation": "ability (with H3027)",
+        "translation": "ability",
         "count": 1
       },
       {
         "translation": "able",
-        "count": 1
-      },
-      {
-        "translation": "able (with H1767)",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "bring",
@@ -293668,7 +290126,7 @@
     "english_translations": [
       {
         "translation": "prince",
-        "count": 96
+        "count": 97
       },
       {
         "translation": "captain",
@@ -293676,7 +290134,7 @@
       },
       {
         "translation": "chief",
-        "count": 10
+        "count": 11
       },
       {
         "translation": "ruler",
@@ -293691,19 +290149,11 @@
         "count": 1
       },
       {
-        "translation": "chief (with H5387)",
-        "count": 1
-      },
-      {
         "translation": "clouds",
         "count": 1
       },
       {
         "translation": "part",
-        "count": 1
-      },
-      {
-        "translation": "prince (with H5387)",
         "count": 1
       }
     ],
@@ -294018,11 +290468,7 @@
         "count": 1
       },
       {
-        "translation": "dawning of the morning",
-        "count": null
-      },
-      {
-        "translation": "dawning of the day",
+        "translation": "dawning of the morning, dawning of the day",
         "count": 1
       }
     ],
@@ -294326,7 +290772,7 @@
         "count": 2
       },
       {
-        "translation": "byways (with H6128)",
+        "translation": "byways",
         "count": 1
       },
       {
@@ -295235,15 +291681,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(stood",
-        "count": null
-      },
-      {
-        "translation": "turned",
-        "count": null
-      },
-      {
-        "translation": "etc...) about",
+        "translation": "(stood, turned, etc...) about",
         "count": 54
       },
       {
@@ -296505,14 +292943,10 @@
       },
       {
         "translation": "horseback",
-        "count": 2
+        "count": 4
       },
       {
-        "translation": "horseback (with H7392)",
-        "count": 2
-      },
-      {
-        "translation": "horsehoofs (with H6119)",
+        "translation": "horsehoofs",
         "count": 1
       }
     ],
@@ -296774,15 +293208,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(put",
-        "count": null
-      },
-      {
-        "translation": "take",
-        "count": null
-      },
-      {
-        "translation": "...) away",
+        "translation": "(put, take, ...) away",
         "count": 97
       },
       {
@@ -297098,7 +293524,7 @@
         "count": 1
       },
       {
-        "translation": "merchantmen (with H582)",
+        "translation": "merchantmen",
         "count": 1
       },
       {
@@ -297450,7 +293876,7 @@
         "count": 4
       },
       {
-        "translation": "washpot (with H7366)",
+        "translation": "washpot",
         "count": 2
       },
       {
@@ -297458,7 +293884,7 @@
         "count": 1
       },
       {
-        "translation": "fishhooks (with H1729)",
+        "translation": "fishhooks",
         "count": 1
       }
     ],
@@ -297956,10 +294382,6 @@
       {
         "translation": "give over",
         "count": 1
-      },
-      {
-        "translation": "impoverished",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -299398,7 +295820,7 @@
     "english_translations": [
       {
         "translation": "whirlwind",
-        "count": 12
+        "count": 13
       },
       {
         "translation": "tempest",
@@ -299410,10 +295832,6 @@
       },
       {
         "translation": "storm",
-        "count": 1
-      },
-      {
-        "translation": "whirlwind (with H7307)",
         "count": 1
       }
     ],
@@ -299983,7 +296401,7 @@
         "count": 1
       },
       {
-        "translation": "penknife (with H8593)",
+        "translation": "penknife",
         "count": 1
       },
       {
@@ -300114,7 +296532,7 @@
         "count": 1
       },
       {
-        "translation": "learned (with H3045)",
+        "translation": "learned",
         "count": 1
       },
       {
@@ -301188,7 +297606,7 @@
     "english_translations": [
       {
         "translation": "do",
-        "count": 10
+        "count": 13
       },
       {
         "translation": "made",
@@ -301199,19 +297617,11 @@
         "count": 2
       },
       {
-        "translation": "do (with H1934)",
-        "count": 2
-      },
-      {
-        "translation": "do (with H5922)",
-        "count": 1
-      },
-      {
         "translation": "worketh",
         "count": 1
       },
       {
-        "translation": "executed (with H1934)",
+        "translation": "executed",
         "count": 1
       },
       {
@@ -301754,45 +298164,6 @@
     ]
   },
   {
-    "concord_id": "H5668",
-    "original_word": "עֲבוּר",
-    "transliteration": "ʿăḇûr",
-    "part_of_speech": "conjunction, preposition",
-    "english_translations": [
-      {
-        "translation": "sake",
-        "count": null
-      },
-      {
-        "translation": "that",
-        "count": null
-      },
-      {
-        "translation": "because of",
-        "count": null
-      },
-      {
-        "translation": "to",
-        "count": null
-      },
-      {
-        "translation": "to the intent that",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "for the sake of, on account of, because of, in order to",
-      "in order that"
-    ],
-    "strongs_definition": [
-      "עָבוּר ʻâbûwr, aw-boor'",
-      "or עָבֻר ʻâbur",
-      "passive participle of H5674",
-      "properly, crossed, i.e. (abstractly) transit",
-      "used only adverbially, on account of, in order that:—because of, for (...'s sake), (intent) that, to."
-    ]
-  },
-  {
     "concord_id": "H5669",
     "original_word": "עָבוּר",
     "transliteration": "ʿāḇûr",
@@ -301936,15 +298307,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(pass",
-        "count": null
-      },
-      {
-        "translation": "went",
-        "count": null
-      },
-      {
-        "translation": "...) over",
+        "translation": "(pass, went, ...) over",
         "count": 174
       },
       {
@@ -301952,11 +298315,7 @@
         "count": 108
       },
       {
-        "translation": "(pass",
-        "count": null
-      },
-      {
-        "translation": "ect...) through",
+        "translation": "(pass, ect...) through",
         "count": 58
       },
       {
@@ -301968,15 +298327,7 @@
         "count": 26
       },
       {
-        "translation": "(put",
-        "count": null
-      },
-      {
-        "translation": "pass",
-        "count": null
-      },
-      {
-        "translation": "etc...) away",
+        "translation": "(put, pass, etc...) away",
         "count": 24
       },
       {
@@ -302203,15 +298554,11 @@
     "english_translations": [
       {
         "translation": "Hebrew",
-        "count": 29
+        "count": 30
       },
       {
         "translation": "Hebrew woman",
         "count": 2
-      },
-      {
-        "translation": "Hebrew (with H376)",
-        "count": 1
       },
       {
         "translation": "Hebrewess",
@@ -302753,7 +299100,7 @@
     "english_translations": [
       {
         "translation": "ever",
-        "count": 41
+        "count": 42
       },
       {
         "translation": "everlasting",
@@ -302765,10 +299112,6 @@
       },
       {
         "translation": "eternity",
-        "count": 1
-      },
-      {
-        "translation": "ever (with H5769)",
         "count": 1
       },
       {
@@ -302795,56 +299138,6 @@
       "עַד ʻad, ad",
       "from H5710",
       "properly, a (peremptory) terminus, i.e. (by implication) duration, in the sense of advance or perpetuity (substantially as a noun, either with or without a preposition):—eternity, ever(-lasting, -more), old, perpetually, world without end."
-    ]
-  },
-  {
-    "concord_id": "H5704",
-    "original_word": "עַד",
-    "transliteration": "ʿaḏ",
-    "part_of_speech": "conjunction, preposition",
-    "english_translations": [
-      {
-        "translation": "by",
-        "count": null
-      },
-      {
-        "translation": "as long",
-        "count": null
-      },
-      {
-        "translation": "hitherto",
-        "count": null
-      },
-      {
-        "translation": "when",
-        "count": null
-      },
-      {
-        "translation": "how long",
-        "count": null
-      },
-      {
-        "translation": "as yet",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "as far as, even to, until, up to, while, as far as",
-      "of space",
-      "as far as, up to, even to",
-      "in combination",
-      "from...as far as, both...and (with 'min' - from)",
-      "of time",
-      "even to, until, unto, till, during, end",
-      "of degree",
-      "even to, to the degree of, even like",
-      "until, while, to the point that, so that even"
-    ],
-    "strongs_definition": [
-      "עַד ʻad, ad",
-      "properly, the same as H5703 (used as a preposition, adverb or conjunction",
-      "especially with a preposition)",
-      "as far (or long, or much) as, whether of space (even unto) or time (during, while, until) or degree (equally with):—against, and, as, at, before, by (that), even (to), for(-asmuch as), (hither-) to, how long, into, as long (much) as, (so) that, till, toward, until, when, while, (+ as) yet."
     ]
   },
   {
@@ -302886,11 +299179,11 @@
         "count": 1
       },
       {
-        "translation": "hitherto (with H3542)",
+        "translation": "hitherto",
         "count": 1
       },
       {
-        "translation": "mastery (with H7981)",
+        "translation": "mastery",
         "count": 1
       },
       {
@@ -304079,61 +300372,6 @@
     ]
   },
   {
-    "concord_id": "H5750",
-    "original_word": "עוֹד",
-    "transliteration": "ʿôḏ",
-    "part_of_speech": "adverb, substantive",
-    "english_translations": [
-      {
-        "translation": "again",
-        "count": null
-      },
-      {
-        "translation": "more",
-        "count": null
-      },
-      {
-        "translation": "good while",
-        "count": null
-      },
-      {
-        "translation": "longer",
-        "count": null
-      },
-      {
-        "translation": "else",
-        "count": null
-      },
-      {
-        "translation": "since",
-        "count": null
-      },
-      {
-        "translation": "yet",
-        "count": null
-      },
-      {
-        "translation": "still",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "a going round, continuance",
-      "still, yet, again, besides",
-      "still, yet (of continuance or persistence)",
-      "still, yet, more (of addition or repetition)",
-      "again",
-      "still, moreover, besides"
-    ],
-    "strongs_definition": [
-      "עוֹד ʻôwd, ode",
-      "or עֹד ʻôd",
-      "from H5749",
-      "properly, iteration or continuance",
-      "used only adverbially (with or without preposition), again, repeatedly, still, more:—again, × all life long, at all, besides, but, else, further(-more), henceforth, (any) longer, (any) more(-over), × once, since, (be) still, when, (good, the) while (having being), (as, because, whether, while) yet (within)."
-    ]
-  },
-  {
     "concord_id": "H5751",
     "original_word": "עוֹד",
     "transliteration": "ʿôḏ",
@@ -304690,7 +300928,7 @@
       },
       {
         "translation": "never",
-        "count": 13
+        "count": 15
       },
       {
         "translation": "time",
@@ -304718,10 +300956,6 @@
       },
       {
         "translation": "more",
-        "count": 2
-      },
-      {
-        "translation": "never (with H408)",
         "count": 2
       },
       {
@@ -304786,7 +301020,7 @@
         "count": 2
       },
       {
-        "translation": "Iniquities (with H1697)",
+        "translation": "Iniquities",
         "count": 1
       },
       {
@@ -304864,11 +301098,7 @@
         "count": 17
       },
       {
-        "translation": "(fly",
-        "count": null
-      },
-      {
-        "translation": "flee...) away",
+        "translation": "(fly, flee...) away",
         "count": 6
       },
       {
@@ -305091,11 +301321,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(stir",
-        "count": null
-      },
-      {
-        "translation": "lift....) up",
+        "translation": "(stir, lift....) up",
         "count": 40
       },
       {
@@ -305480,19 +301706,15 @@
         "count": 63
       },
       {
-        "translation": "kid (with H1423)",
-        "count": 5
-      },
-      {
         "translation": "kid",
-        "count": 4
+        "count": 9
       },
       {
         "translation": "he",
         "count": 1
       },
       {
-        "translation": "kids (with H1121)",
+        "translation": "kids",
         "count": 1
       }
     ],
@@ -307459,24 +303681,20 @@
         "count": 10
       },
       {
-        "translation": "pleased (with H3190)",
-        "count": 10
+        "translation": "pleased",
+        "count": 14
       },
       {
         "translation": "presence",
         "count": 8
       },
       {
-        "translation": "displeased (with H3415)",
+        "translation": "displeased",
         "count": 8
       },
       {
         "translation": "before",
         "count": 8
-      },
-      {
-        "translation": "pleased (with H3474)",
-        "count": 4
       },
       {
         "translation": "conceit",
@@ -308689,91 +304907,6 @@
     ]
   },
   {
-    "concord_id": "H5921",
-    "original_word": "עַל",
-    "transliteration": "ʿal",
-    "part_of_speech": "conjunction, preposition",
-    "english_translations": [
-      {
-        "translation": "upon",
-        "count": null
-      },
-      {
-        "translation": "in",
-        "count": null
-      },
-      {
-        "translation": "on",
-        "count": null
-      },
-      {
-        "translation": "over",
-        "count": null
-      },
-      {
-        "translation": "by",
-        "count": null
-      },
-      {
-        "translation": "for",
-        "count": null
-      },
-      {
-        "translation": "both",
-        "count": null
-      },
-      {
-        "translation": "beyond",
-        "count": null
-      },
-      {
-        "translation": "through",
-        "count": null
-      },
-      {
-        "translation": "throughout",
-        "count": null
-      },
-      {
-        "translation": "against",
-        "count": null
-      },
-      {
-        "translation": "beside",
-        "count": null
-      },
-      {
-        "translation": "forth",
-        "count": null
-      },
-      {
-        "translation": "off",
-        "count": null
-      },
-      {
-        "translation": "from off",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "upon, on the ground of, according to, on account of, on behalf of, concerning, beside, in addition to, together with, beyond, above, over, by, on to, towards, to, against",
-      "upon, on the ground of, on the basis of, on account of, because of, therefore, on behalf of, for the sake of, for, with, in spite of, notwithstanding, concerning, in the matter of, as regards",
-      "above, beyond, over (of excess)",
-      "above, over (of elevation or pre-eminence)",
-      "upon, to, over to, unto, in addition to, together with, with (of addition)",
-      "over (of suspension or extension)",
-      "by, adjoining, next, at, over, around (of contiguity or proximity)",
-      "down upon, upon, on, from, up upon, up to,, towards, over towards, to, against (with verbs of motion)",
-      "to (as a dative)",
-      "because that, because, notwithstanding, although"
-    ],
-    "strongs_definition": [
-      "עַל ʻal, al",
-      "properly, the same as H5920 used as a preposition (in the singular or plural often with prefix, or as conjunction with a particle following)",
-      "above, over, upon, or against (yet always in this last relation with a downward aspect) in a great variety of applications:—above, according to(-ly), after, (as) against, among, and, × as, at, because of, beside (the rest of), between, beyond the time, × both and, by (reason of), × had the charge of, concerning for, in (that), (forth, out) of, (from) (off), (up-) on, over, than, through(-out), to, touching, × with."
-    ]
-  },
-  {
     "concord_id": "H5922",
     "original_word": "עַל",
     "transliteration": "ʿal",
@@ -308926,11 +305059,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(come",
-        "count": null
-      },
-      {
-        "translation": "etc...) up",
+        "translation": "(come, etc...) up",
         "count": 676
       },
       {
@@ -309079,7 +305208,7 @@
         "count": 5
       },
       {
-        "translation": "branches (with H6086)",
+        "translation": "branches",
         "count": 1
       }
     ],
@@ -309827,10 +305956,6 @@
       {
         "translation": "gleaning of the grape",
         "count": 1
-      },
-      {
-        "translation": "grapes",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -309901,7 +306026,7 @@
     "english_translations": [
       {
         "translation": "ever",
-        "count": 12
+        "count": 13
       },
       {
         "translation": "everlasting",
@@ -309910,10 +306035,6 @@
       {
         "translation": "old",
         "count": 2
-      },
-      {
-        "translation": "ever (with H5705)",
-        "count": 1
       },
       {
         "translation": "never",
@@ -310259,15 +306380,11 @@
     "english_translations": [
       {
         "translation": "people",
-        "count": 1836
+        "count": 1840
       },
       {
         "translation": "nation",
         "count": 17
-      },
-      {
-        "translation": "people (with H1121)",
-        "count": 4
       },
       {
         "translation": "folk",
@@ -310318,58 +306435,6 @@
     "strongs_definition": [
       "עַם ʻam, am",
       "(Aramaic) corresponding to H5971:—people."
-    ]
-  },
-  {
-    "concord_id": "H5973",
-    "original_word": "עִם",
-    "transliteration": "ʿim",
-    "part_of_speech": "preposition",
-    "english_translations": [
-      {
-        "translation": "with",
-        "count": null
-      },
-      {
-        "translation": "unto",
-        "count": null
-      },
-      {
-        "translation": "by",
-        "count": null
-      },
-      {
-        "translation": "as long",
-        "count": null
-      },
-      {
-        "translation": "neither",
-        "count": null
-      },
-      {
-        "translation": "from between",
-        "count": null
-      },
-      {
-        "translation": "from among",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "with",
-      "with",
-      "against",
-      "toward",
-      "as long as",
-      "beside, except",
-      "in spite of"
-    ],
-    "strongs_definition": [
-      "עִם ʻim, eem",
-      "from H6004",
-      "adverb or preposition, with (i.e. in conjunction with), in varied applications",
-      "specifically, equally with",
-      "often with prepositional prefix (and then usually unrepresented in English):—accompanying, against, and, as (× long as), before, beside, by (reason of), for all, from (among, between), in, like, more than, of, (un-) to, with(-al)."
     ]
   },
   {
@@ -310436,11 +306501,7 @@
         "count": 137
       },
       {
-        "translation": "(raise",
-        "count": null
-      },
-      {
-        "translation": "stand...) up",
+        "translation": "(raise, stand...) up",
         "count": 42
       },
       {
@@ -310569,42 +306630,6 @@
     ]
   },
   {
-    "concord_id": "H5978",
-    "original_word": "עִמָּד",
-    "transliteration": "ʿimmāḏ",
-    "part_of_speech": "preposition",
-    "english_translations": [
-      {
-        "translation": "with me",
-        "count": null
-      },
-      {
-        "translation": "by me",
-        "count": null
-      },
-      {
-        "translation": "upon me",
-        "count": null
-      },
-      {
-        "translation": "mine",
-        "count": null
-      },
-      {
-        "translation": "against me",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "with"
-    ],
-    "strongs_definition": [
-      "עִמָּד ʻimmâd, im-mawd'",
-      "prolonged for H5973",
-      "along with:—against, by, from, + me, + mine, of, + that I take, unto, upon, with(-in.)"
-    ]
-  },
-  {
     "concord_id": "H5979",
     "original_word": "עֶמְדָּה",
     "transliteration": "ʿemdâ",
@@ -310702,7 +306727,7 @@
         "count": 109
       },
       {
-        "translation": "apiece (with H259)",
+        "translation": "apiece",
         "count": 1
       }
     ],
@@ -310731,12 +306756,8 @@
         "count": 90
       },
       {
-        "translation": "Ammonites (with H1121)",
-        "count": 13
-      },
-      {
         "translation": "Ammonites",
-        "count": 2
+        "count": 15
       }
     ],
     "outline_definitions": [
@@ -311285,11 +307306,7 @@
     "english_translations": [
       {
         "translation": "Amalekite",
-        "count": 11
-      },
-      {
-        "translation": "Amalekite (with H376)",
-        "count": 1
+        "count": 12
       }
     ],
     "outline_definitions": [
@@ -311336,7 +307353,7 @@
     "part_of_speech": "proper masculine noun",
     "english_translations": [
       {
-        "translation": "Immanuel (with H410)",
+        "translation": "Immanuel",
         "count": 2
       }
     ],
@@ -312334,7 +308351,7 @@
         "count": 3
       },
       {
-        "translation": "afflicted (with H1121)",
+        "translation": "afflicted",
         "count": 1
       },
       {
@@ -313509,7 +309526,7 @@
         "count": 4
       },
       {
-        "translation": "carpenter (with H2796)",
+        "translation": "carpenter",
         "count": 2
       },
       {
@@ -313851,7 +309868,7 @@
     "english_translations": [
       {
         "translation": "counsel",
-        "count": 79
+        "count": 80
       },
       {
         "translation": "counsels",
@@ -313866,7 +309883,7 @@
         "count": 1
       },
       {
-        "translation": "counsellors (with H582)",
+        "translation": "counsellors",
         "count": 1
       },
       {
@@ -313874,11 +309891,7 @@
         "count": 1
       },
       {
-        "translation": "counsel (with H3289)",
-        "count": 1
-      },
-      {
-        "translation": "counsellor (with H376)",
+        "translation": "counsellor",
         "count": 1
       }
     ],
@@ -314476,11 +310489,7 @@
         "count": 1
       },
       {
-        "translation": "stay",
-        "count": null
-      },
-      {
-        "translation": "utterly",
+        "translation": "stay, utterly",
         "count": 1
       }
     ],
@@ -314506,7 +310515,7 @@
     "english_translations": [
       {
         "translation": "because",
-        "count": 6
+        "count": 7
       },
       {
         "translation": "reward",
@@ -314515,10 +310524,6 @@
       {
         "translation": "end",
         "count": 2
-      },
-      {
-        "translation": "because (with H834)",
-        "count": 1
       },
       {
         "translation": "by",
@@ -314688,26 +310693,6 @@
     ]
   },
   {
-    "concord_id": "H6124",
-    "original_word": "עָקֹד",
-    "transliteration": "ʿāqōḏ",
-    "part_of_speech": "adjective",
-    "english_translations": [
-      {
-        "translation": "ringstraked",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "streaked, striped"
-    ],
-    "strongs_definition": [
-      "עָקֹד ʻâqôd, aw-kode'",
-      "from H6123",
-      "striped (with bands):—ring straked."
-    ]
-  },
-  {
     "concord_id": "H6125",
     "original_word": "עָקָה",
     "transliteration": "ʿāqâ",
@@ -314782,7 +310767,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "byways (with H5410)",
+        "translation": "byways",
         "count": 1
       },
       {
@@ -315419,11 +311404,11 @@
     "english_translations": [
       {
         "translation": "even",
-        "count": 72
+        "count": 73
       },
       {
         "translation": "evening",
-        "count": 47
+        "count": 49
       },
       {
         "translation": "night",
@@ -315439,10 +311424,10 @@
       },
       {
         "translation": "eventide",
-        "count": 2
+        "count": 3
       },
       {
-        "translation": "eveningtide (with H6256)",
+        "translation": "eveningtide",
         "count": 2
       },
       {
@@ -315451,22 +311436,6 @@
       },
       {
         "translation": "days",
-        "count": 1
-      },
-      {
-        "translation": "even (with H996)",
-        "count": 1
-      },
-      {
-        "translation": "evening (with H3117)",
-        "count": 1
-      },
-      {
-        "translation": "evening (with H6256)",
-        "count": 1
-      },
-      {
-        "translation": "eventide (with H6256)",
         "count": 1
       }
     ],
@@ -315957,11 +311926,7 @@
     "english_translations": [
       {
         "translation": "nakedness",
-        "count": 50
-      },
-      {
-        "translation": "nakedness (with H1320)",
-        "count": 1
+        "count": 51
       },
       {
         "translation": "shame",
@@ -316845,19 +312810,11 @@
         "count": 7
       },
       {
-        "translation": "stiffnecked (with H7186)",
-        "count": 4
-      },
-      {
         "translation": "stiffnecked",
-        "count": 3
+        "count": 8
       },
       {
-        "translation": "backs (with H310)",
-        "count": 1
-      },
-      {
-        "translation": "stiffnecked (with H7185)",
+        "translation": "backs",
         "count": 1
       }
     ],
@@ -317753,7 +313710,7 @@
     "english_translations": [
       {
         "translation": "oppression",
-        "count": 11
+        "count": 12
       },
       {
         "translation": "cruelly",
@@ -317761,10 +313718,6 @@
       },
       {
         "translation": "extortion",
-        "count": 1
-      },
-      {
-        "translation": "oppression (with H6231)",
         "count": 1
       },
       {
@@ -317815,11 +313768,11 @@
         "count": 172
       },
       {
-        "translation": "fifteen (with H2568)",
+        "translation": "fifteen",
         "count": 1
       },
       {
-        "translation": "seventeen (with H7651)",
+        "translation": "seventeen",
         "count": 1
       },
       {
@@ -317850,7 +313803,7 @@
         "count": 4
       },
       {
-        "translation": "twelve (with H8648)",
+        "translation": "twelve",
         "count": 2
       }
     ],
@@ -317970,35 +313923,27 @@
     "part_of_speech": "masculine/feminine noun",
     "english_translations": [
       {
-        "translation": "eleven (with H259)",
-        "count": 9
+        "translation": "eleven",
+        "count": 15
       },
       {
-        "translation": "eleven (with H6249)",
-        "count": 6
+        "translation": "eleventh",
+        "count": 17
       },
       {
-        "translation": "eleventh (with H6249)",
-        "count": 13
-      },
-      {
-        "translation": "eleventh (with H259)",
-        "count": 4
-      },
-      {
-        "translation": "twelve (with H8147)",
+        "translation": "twelve",
         "count": 106
       },
       {
-        "translation": "twelfth (with H8147)",
+        "translation": "twelfth",
         "count": 21
       },
       {
-        "translation": "thirteen (with H7969)",
+        "translation": "thirteen",
         "count": 13
       },
       {
-        "translation": "thirteenth (with H7969)",
+        "translation": "thirteenth",
         "count": 11
       },
       {
@@ -318057,7 +314002,7 @@
         "count": 36
       },
       {
-        "translation": "sixscore (with H3967)",
+        "translation": "sixscore",
         "count": 1
       }
     ],
@@ -318203,7 +314148,7 @@
     "part_of_speech": "masculine/feminine noun",
     "english_translations": [
       {
-        "translation": "eleven (with H2640)",
+        "translation": "eleven",
         "count": 19
       }
     ],
@@ -318373,7 +314318,7 @@
         "count": 4
       },
       {
-        "translation": "eveningtide (with H6153)",
+        "translation": "eveningtide",
         "count": 2
       },
       {
@@ -318418,44 +314363,6 @@
       "עָתַד ʻâthad, aw-thad'",
       "a primitive root",
       "to prepare:—make fit, be ready to become."
-    ]
-  },
-  {
-    "concord_id": "H6258",
-    "original_word": "עַתָּה",
-    "transliteration": "ʿatâ",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "now",
-        "count": null
-      },
-      {
-        "translation": "whereas",
-        "count": null
-      },
-      {
-        "translation": "henceforth",
-        "count": null
-      },
-      {
-        "translation": "this time forth",
-        "count": null
-      },
-      {
-        "translation": "straightway",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "now",
-      "now",
-      "in phrases"
-    ],
-    "strongs_definition": [
-      "עַתָּה ʻattâh, at-taw'",
-      "from H6256",
-      "at this time, whether adverb, conjunction or expletive:—henceforth, now, straightway, this time, whereas."
     ]
   },
   {
@@ -319877,46 +315784,6 @@
     ]
   },
   {
-    "concord_id": "H6311",
-    "original_word": "פֹּה",
-    "transliteration": "pô",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "here",
-        "count": null
-      },
-      {
-        "translation": "hither",
-        "count": null
-      },
-      {
-        "translation": "this side",
-        "count": null
-      },
-      {
-        "translation": "one side",
-        "count": null
-      },
-      {
-        "translation": "other side",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "here, from here, hither",
-      "here",
-      "hither"
-    ],
-    "strongs_definition": [
-      "פֹּה pôh, po",
-      "or פֹּא pôʼ",
-      "(Job 38:11), or פּוֹ pôw",
-      "probably from a primitive inseparable particle 'p' (of demonstrative force) and H1931",
-      "this place (French ici), i.e. here or hence:—here, hither, the one (other, this, that) side."
-    ]
-  },
-  {
     "concord_id": "H6312",
     "original_word": "פּוּאָה",
     "transliteration": "pû'â",
@@ -320742,7 +316609,7 @@
         "count": 2
       },
       {
-        "translation": "snares (with H3027)",
+        "translation": "snares",
         "count": 1
       }
     ],
@@ -321434,11 +317301,7 @@
     "english_translations": [
       {
         "translation": "concubine",
-        "count": 35
-      },
-      {
-        "translation": "concubine (with H802)",
-        "count": 1
+        "count": 36
       },
       {
         "translation": "paramours",
@@ -321685,11 +317548,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(wondrous",
-        "count": null
-      },
-      {
-        "translation": "marvellous...) work",
+        "translation": "(wondrous, marvellous...) work",
         "count": 18
       },
       {
@@ -323099,36 +318958,6 @@
     ]
   },
   {
-    "concord_id": "H6435",
-    "original_word": "פֵּן",
-    "transliteration": "pēn",
-    "part_of_speech": "adverb, conjunction",
-    "english_translations": [
-      {
-        "translation": "lest",
-        "count": null
-      },
-      {
-        "translation": "that...not",
-        "count": null
-      },
-      {
-        "translation": "peradventure",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "lest, not, beware lest",
-      "lest"
-    ],
-    "strongs_definition": [
-      "פֵּן pên, pane",
-      "from H6437",
-      "properly, removal",
-      "used only (in the construction) adverb as conjunction, lest:—(lest) (peradventure), that...not."
-    ]
-  },
-  {
     "concord_id": "H6436",
     "original_word": "פַּנַּג",
     "transliteration": "pannaḡ",
@@ -323394,11 +319223,7 @@
         "count": 2
       },
       {
-        "translation": "in",
-        "count": null
-      },
-      {
-        "translation": "inner part",
+        "translation": "in, inner part",
         "count": 1
       }
     ],
@@ -324192,7 +320017,7 @@
         "count": 5
       },
       {
-        "translation": "thrice (with H7969)",
+        "translation": "thrice",
         "count": 4
       },
       {
@@ -325848,7 +321673,7 @@
         "count": 1
       },
       {
-        "translation": "firstfruits (with H7225)",
+        "translation": "firstfruits",
         "count": 1
       },
       {
@@ -327107,11 +322932,7 @@
     "english_translations": [
       {
         "translation": "horsemen",
-        "count": 56
-      },
-      {
-        "translation": "horsemen (with H1167)",
-        "count": 1
+        "count": 57
       }
     ],
     "outline_definitions": [
@@ -328027,7 +323848,7 @@
         "count": 1
       },
       {
-        "translation": "grave (with H6605)",
+        "translation": "grave",
         "count": 1
       },
       {
@@ -328689,10 +324510,6 @@
       {
         "translation": "that which cometh from thee",
         "count": 1
-      },
-      {
-        "translation": "that cometh out of",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -328737,46 +324554,30 @@
       },
       {
         "translation": "sheep",
-        "count": 110
+        "count": 111
       },
       {
         "translation": "cattle",
         "count": 15
       },
       {
-        "translation": "shepherd (with H7462)",
-        "count": 2
-      },
-      {
-        "translation": "lamb (with H1121)",
-        "count": 2
+        "translation": "shepherd",
+        "count": 3
       },
       {
         "translation": "lamb",
+        "count": 3
+      },
+      {
+        "translation": "sheepcotes",
         "count": 1
       },
       {
-        "translation": "sheep (with H4480)",
-        "count": 1
+        "translation": "sheepfold",
+        "count": 2
       },
       {
-        "translation": "sheepcotes (with H1448)",
-        "count": 1
-      },
-      {
-        "translation": "sheepfold (with H1448)",
-        "count": 1
-      },
-      {
-        "translation": "sheepfold (with H4356)",
-        "count": 1
-      },
-      {
-        "translation": "sheepshearers (with H1494)",
-        "count": 1
-      },
-      {
-        "translation": "shepherd (with H7462)",
+        "translation": "sheepshearers",
         "count": 1
       }
     ],
@@ -330055,7 +325856,7 @@
         "count": 1
       },
       {
-        "translation": "noontide (with H6256)",
+        "translation": "noontide",
         "count": 1
       },
       {
@@ -330209,11 +326010,7 @@
     "english_translations": [
       {
         "translation": "Zobah",
-        "count": 10
-      },
-      {
-        "translation": "Zobah",
-        "count": 2
+        "count": 12
       }
     ],
     "outline_definitions": [
@@ -330435,7 +326232,7 @@
         "count": 9
       },
       {
-        "translation": "fasted (with H6684)",
+        "translation": "fasted",
         "count": 1
       }
     ],
@@ -331332,7 +327129,7 @@
       },
       {
         "translation": "hunting",
-        "count": 1
+        "count": 2
       },
       {
         "translation": "catch",
@@ -331340,10 +327137,6 @@
       },
       {
         "translation": "food",
-        "count": 1
-      },
-      {
-        "translation": "hunting",
         "count": 1
       }
     ],
@@ -332735,11 +328528,7 @@
       },
       {
         "translation": "suffer thirst",
-        "count": 1
-      },
-      {
-        "translation": "suffer thirst",
-        "count": 1
+        "count": 2
       }
     ],
     "outline_definitions": [
@@ -332858,11 +328647,7 @@
         "count": 3
       },
       {
-        "translation": "fasten",
-        "count": null
-      },
-      {
-        "translation": "frame",
+        "translation": "fasten, frame",
         "count": 1
       }
     ],
@@ -333851,7 +329636,7 @@
         "count": 1
       },
       {
-        "translation": "young (with H3117)",
+        "translation": "young",
         "count": 1
       }
     ],
@@ -336334,15 +332119,15 @@
     "part_of_speech": "preposition, substantive",
     "english_translations": [
       {
-        "translation": "as (with H3606)",
-        "count": 5
+        "translation": "as",
+        "count": 7
       },
       {
-        "translation": "because (with H3606)",
+        "translation": "because",
         "count": 4
       },
       {
-        "translation": "therefore (with H3606)",
+        "translation": "therefore",
         "count": 3
       },
       {
@@ -336350,11 +332135,7 @@
         "count": 3
       },
       {
-        "translation": "as",
-        "count": 2
-      },
-      {
-        "translation": "wherefore (with H3606)",
+        "translation": "wherefore",
         "count": 2
       },
       {
@@ -336845,11 +332626,7 @@
       },
       {
         "translation": "eastward",
-        "count": 7
-      },
-      {
-        "translation": "eastward (with H1870)",
-        "count": 1
+        "count": 8
       },
       {
         "translation": "east side",
@@ -337021,14 +332798,10 @@
     "english_translations": [
       {
         "translation": "before",
-        "count": 29
+        "count": 31
       },
       {
-        "translation": "before (with H4481)",
-        "count": 2
-      },
-      {
-        "translation": "of (with H4481)",
+        "translation": "of",
         "count": 2
       },
       {
@@ -337125,7 +332898,7 @@
         "count": 1
       },
       {
-        "translation": "aforetime (with H4481) (with H1836)",
+        "translation": "aforetime",
         "count": 1
       }
     ],
@@ -337606,15 +333379,7 @@
         "count": 68
       },
       {
-        "translation": "(holy",
-        "count": null
-      },
-      {
-        "translation": "hallowed",
-        "count": null
-      },
-      {
-        "translation": "...) things",
+        "translation": "(holy, hallowed, ...) things",
         "count": 52
       },
       {
@@ -337692,7 +333457,7 @@
         "count": 17
       },
       {
-        "translation": "Meribahkadesh (with H4808)",
+        "translation": "Meribahkadesh",
         "count": 1
       }
     ],
@@ -337788,11 +333553,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(gather",
-        "count": null
-      },
-      {
-        "translation": "assemble) together",
+        "translation": "(gather, assemble) together",
         "count": 14
       },
       {
@@ -338169,11 +333930,11 @@
         "count": 10
       },
       {
-        "translation": "proclamation (with H5674)",
+        "translation": "proclamation",
         "count": 4
       },
       {
-        "translation": "send out (with H5414)",
+        "translation": "send out",
         "count": 2
       },
       {
@@ -338233,15 +333994,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(stood",
-        "count": null
-      },
-      {
-        "translation": "rise",
-        "count": null
-      },
-      {
-        "translation": "etc...) up",
+        "translation": "(stood, rise, etc...) up",
         "count": 240
       },
       {
@@ -340612,14 +336365,10 @@
       },
       {
         "translation": "sling",
-        "count": 4
+        "count": 5
       },
       {
-        "translation": "sling (with H3709)",
-        "count": 1
-      },
-      {
-        "translation": "slingstones (with H68)",
+        "translation": "slingstones",
         "count": 1
       },
       {
@@ -340905,11 +336654,7 @@
     "english_translations": [
       {
         "translation": "handful",
-        "count": 2
-      },
-      {
-        "translation": "handful (with H4393)",
-        "count": 2
+        "count": 4
       }
     ],
     "outline_definitions": [
@@ -342880,15 +338625,7 @@
         "count": 95
       },
       {
-        "translation": "(come",
-        "count": null
-      },
-      {
-        "translation": "draw",
-        "count": null
-      },
-      {
-        "translation": "..) near",
+        "translation": "(come, draw, ..) near",
         "count": 58
       },
       {
@@ -342896,15 +338633,7 @@
         "count": 58
       },
       {
-        "translation": "(come",
-        "count": null
-      },
-      {
-        "translation": "draw",
-        "count": null
-      },
-      {
-        "translation": "..) nigh",
+        "translation": "(come, draw, ..) nigh",
         "count": 18
       },
       {
@@ -342953,7 +338682,7 @@
       },
       {
         "translation": "offer",
-        "count": 2
+        "count": 3
       },
       {
         "translation": "come",
@@ -342961,10 +338690,6 @@
       },
       {
         "translation": "bring near",
-        "count": 1
-      },
-      {
-        "translation": "offer",
         "count": 1
       }
     ],
@@ -344534,7 +340259,7 @@
         "count": 4
       },
       {
-        "translation": "stiffnecked (with H6203)",
+        "translation": "stiffnecked",
         "count": 2
       },
       {
@@ -344575,7 +340300,7 @@
     "part_of_speech": "adjective",
     "english_translations": [
       {
-        "translation": "stiffnecked (with H6203)",
+        "translation": "stiffnecked",
         "count": 6
       },
       {
@@ -344936,16 +340661,8 @@
         "count": 68
       },
       {
-        "translation": "archers (with H3384)",
-        "count": 3
-      },
-      {
         "translation": "archers",
-        "count": 2
-      },
-      {
-        "translation": "archers (with H1869)",
-        "count": 1
+        "count": 6
       },
       {
         "translation": "miscellaneous",
@@ -345229,7 +340946,7 @@
     "part_of_speech": "infinitive verb",
     "english_translations": [
       {
-        "translation": "beholding (with H7212)",
+        "translation": "beholding",
         "count": 1
       }
     ],
@@ -345637,7 +341354,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "headstone (with H68)",
+        "translation": "headstone",
         "count": 1
       }
     ],
@@ -346087,10 +341804,6 @@
       {
         "translation": "many",
         "count": 1
-      },
-      {
-        "translation": "multiply",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -346284,11 +341997,7 @@
         "count": 4
       },
       {
-        "translation": "forty",
-        "count": null
-      },
-      {
-        "translation": "etc...(thousand)",
+        "translation": "forty, etc...(thousand)",
         "count": 4
       },
       {
@@ -346857,11 +342566,7 @@
     "english_translations": [
       {
         "translation": "Rabshakeh",
-        "count": 15
-      },
-      {
-        "translation": "Rabshakeh (with H5631) (with H7227)",
-        "count": 1
+        "count": 16
       }
     ],
     "outline_definitions": [
@@ -347148,7 +342853,7 @@
         "count": 216
       },
       {
-        "translation": "footstool (with H1916)",
+        "translation": "footstool",
         "count": 6
       },
       {
@@ -347164,7 +342869,7 @@
         "count": 4
       },
       {
-        "translation": "piss (with H4325)",
+        "translation": "piss",
         "count": 2
       },
       {
@@ -347208,11 +342913,7 @@
     "english_translations": [
       {
         "translation": "footman",
-        "count": 7
-      },
-      {
-        "translation": "footman (with H376)",
-        "count": 4
+        "count": 11
       },
       {
         "translation": "foot",
@@ -348367,15 +344068,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(lift",
-        "count": null
-      },
-      {
-        "translation": "hold",
-        "count": null
-      },
-      {
-        "translation": "etc...) up",
+        "translation": "(lift, hold, etc...) up",
         "count": 63
       },
       {
@@ -348785,11 +344478,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(pour",
-        "count": null
-      },
-      {
-        "translation": "draw...) out",
+        "translation": "(pour, draw...) out",
         "count": 7
       },
       {
@@ -349245,7 +344934,7 @@
         "count": 1
       },
       {
-        "translation": "as broad as (with H3651)",
+        "translation": "as broad as",
         "count": 1
       },
       {
@@ -349481,11 +345170,7 @@
     "part_of_speech": "adjective, masculine noun",
     "english_translations": [
       {
-        "translation": "(far",
-        "count": null
-      },
-      {
-        "translation": "afar...) off",
+        "translation": "(far, afar...) off",
         "count": 39
       },
       {
@@ -350599,7 +346284,7 @@
         "count": 3
       },
       {
-        "translation": "fainthearted (with H3824)",
+        "translation": "fainthearted",
         "count": 1
       },
       {
@@ -350611,7 +346296,7 @@
         "count": 1
       },
       {
-        "translation": "tenderhearted (with H3824)",
+        "translation": "tenderhearted",
         "count": 1
       }
     ],
@@ -350910,11 +346595,7 @@
       },
       {
         "translation": "talebearer",
-        "count": 2
-      },
-      {
-        "translation": "talebearer (with H1980)",
-        "count": 1
+        "count": 3
       },
       {
         "translation": "carry tales",
@@ -350944,7 +346625,7 @@
         "count": 2
       },
       {
-        "translation": "fainthearted (with H3824)",
+        "translation": "fainthearted",
         "count": 1
       },
       {
@@ -351206,7 +346887,7 @@
         "count": 1
       },
       {
-        "translation": "bowmen (with H7198)",
+        "translation": "bowmen",
         "count": 1
       },
       {
@@ -351829,7 +347510,7 @@
     "part_of_speech": "proper locative noun, proper masculine noun",
     "english_translations": [
       {
-        "translation": "Ramothgilead (with H1568)",
+        "translation": "Ramothgilead",
         "count": 19
       },
       {
@@ -352461,7 +348142,7 @@
     "english_translations": [
       {
         "translation": "neighbour",
-        "count": 102
+        "count": 103
       },
       {
         "translation": "friend",
@@ -352493,10 +348174,6 @@
       },
       {
         "translation": "lovers",
-        "count": 1
-      },
-      {
-        "translation": "neighbour (with H1121)",
         "count": 1
       }
     ],
@@ -354506,7 +350183,7 @@
     "english_translations": [
       {
         "translation": "slayer",
-        "count": 16
+        "count": 17
       },
       {
         "translation": "murderer",
@@ -354530,10 +350207,6 @@
       },
       {
         "translation": "killing",
-        "count": 1
-      },
-      {
-        "translation": "slayer (with H310)",
         "count": 1
       },
       {
@@ -354833,7 +350506,7 @@
         "count": 1
       },
       {
-        "translation": "leanfleshed (with H1320)",
+        "translation": "leanfleshed",
         "count": 1
       }
     ],
@@ -354844,53 +350517,6 @@
       "רַק raq, rak",
       "from H7556 in its original sense",
       "emaciated (as if flattened out):—lean(-fleshed), thin."
-    ]
-  },
-  {
-    "concord_id": "H7535",
-    "original_word": "רַק",
-    "transliteration": "raq",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "only",
-        "count": null
-      },
-      {
-        "translation": "surely",
-        "count": null
-      },
-      {
-        "translation": "nothing but",
-        "count": null
-      },
-      {
-        "translation": "except",
-        "count": null
-      },
-      {
-        "translation": "but",
-        "count": null
-      },
-      {
-        "translation": "in any wise",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "only, altogether, surely",
-      "only",
-      "only, nought but, altogether (in limitation)",
-      "save, except (after a negative)",
-      "only, altogether, surely (with an affirmative)",
-      "if only, provided only (prefixed for emphasis)",
-      "only, exclusively (for emphasis)"
-    ],
-    "strongs_definition": [
-      "רַק raq, rak",
-      "the same as H7534 as a noun",
-      "properly, leanness, i.e. (figuratively) limitation",
-      "only adverbial, merely, or conjunctional, although:—but, even, except, howbeit howsoever, at the least, nevertheless, nothing but, notwithstanding, only, save, so (that), surely, yet (so), in any wise."
     ]
   },
   {
@@ -355261,12 +350887,8 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "needlework (with H4639)",
-        "count": 4
-      },
-      {
         "translation": "needlework",
-        "count": 2
+        "count": 6
       },
       {
         "translation": "embroiderer",
@@ -355770,7 +351392,7 @@
         "count": 20
       },
       {
-        "translation": "network (with H4639)",
+        "translation": "network",
         "count": 1
       }
     ],
@@ -356130,7 +351752,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "wondering (with H8693)",
+        "translation": "wondering",
         "count": 1
       }
     ],
@@ -356840,15 +352462,11 @@
     "english_translations": [
       {
         "translation": "rest",
-        "count": 9
+        "count": 10
       },
       {
         "translation": "residue",
         "count": 2
-      },
-      {
-        "translation": "rest",
-        "count": 1
       }
     ],
     "outline_definitions": [
@@ -357162,27 +352780,11 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(carry",
-        "count": null
-      },
-      {
-        "translation": "take away",
-        "count": null
-      },
-      {
-        "translation": "...) captive",
+        "translation": "(carry, take away, ...) captive",
         "count": 37
       },
       {
-        "translation": "(take",
-        "count": null
-      },
-      {
-        "translation": "drive",
-        "count": null
-      },
-      {
-        "translation": "...) away",
+        "translation": "(take, drive, ...) away",
         "count": 8
       },
       {
@@ -357293,7 +352895,7 @@
         "count": 28
       },
       {
-        "translation": "sworn (with H1167)",
+        "translation": "sworn",
         "count": 1
       },
       {
@@ -357865,7 +353467,7 @@
         "count": 1
       },
       {
-        "translation": "waterflood (with H4325)",
+        "translation": "waterflood",
         "count": 1
       }
     ],
@@ -358197,23 +353799,19 @@
         "count": 13
       },
       {
-        "translation": "seventeen (with H6240)",
-        "count": 8
+        "translation": "seventeen",
+        "count": 10
       },
       {
         "translation": "seven times",
         "count": 6
       },
       {
-        "translation": "seventeenth (with H6240)",
-        "count": 6
-      },
-      {
         "translation": "seventeenth",
-        "count": 5
+        "count": 11
       },
       {
-        "translation": "sevens (with H7657)",
+        "translation": "sevens",
         "count": 2
       },
       {
@@ -358222,14 +353820,6 @@
       },
       {
         "translation": "sevenfold",
-        "count": 1
-      },
-      {
-        "translation": "seventeen (with H6235)",
-        "count": 1
-      },
-      {
-        "translation": "seventeen (with H7657)",
         "count": 1
       }
     ],
@@ -358381,15 +353971,7 @@
         "count": 58
       },
       {
-        "translation": "three score and (ten",
-        "count": null
-      },
-      {
-        "translation": "twelve",
-        "count": null
-      },
-      {
-        "translation": "etc...)",
+        "translation": "three score and (ten, twelve, etc...)",
         "count": 33
       }
     ],
@@ -359209,11 +354791,7 @@
     "part_of_speech": "feminine noun",
     "english_translations": [
       {
-        "translation": "(through",
-        "count": null
-      },
-      {
-        "translation": "in...) ignorance",
+        "translation": "(through, in...) ignorance",
         "count": 12
       },
       {
@@ -360111,14 +355689,10 @@
       },
       {
         "translation": "lamb",
-        "count": 16
+        "count": 17
       },
       {
         "translation": "ewe",
-        "count": 1
-      },
-      {
-        "translation": "lamb (with H3532)",
         "count": 1
       }
     ],
@@ -364967,7 +360541,7 @@
     "english_translations": [
       {
         "translation": "song",
-        "count": 74
+        "count": 75
       },
       {
         "translation": "musick",
@@ -364987,10 +360561,6 @@
       },
       {
         "translation": "singers",
-        "count": 1
-      },
-      {
-        "translation": "song (with H1697)",
         "count": 1
       }
     ],
@@ -365921,11 +361491,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "have",
-        "count": null
-      },
-      {
-        "translation": "after you have lost the other",
+        "translation": "have, after you have lost the other",
         "count": 1
       }
     ],
@@ -365965,15 +361531,7 @@
     "part_of_speech": "verb",
     "english_translations": [
       {
-        "translation": "(rise up",
-        "count": null
-      },
-      {
-        "translation": "get you",
-        "count": null
-      },
-      {
-        "translation": "...) early",
+        "translation": "(rise up, get you, ...) early",
         "count": 61
       },
       {
@@ -367104,7 +362662,7 @@
         "count": 5
       },
       {
-        "translation": "salute (with H7592)",
+        "translation": "salute",
         "count": 4
       },
       {
@@ -367248,11 +362806,11 @@
         "count": 388
       },
       {
-        "translation": "thirteen (with H6240)",
+        "translation": "thirteen",
         "count": 13
       },
       {
-        "translation": "thirteenth (with H6240)",
+        "translation": "thirteenth",
         "count": 11
       },
       {
@@ -367260,11 +362818,11 @@
         "count": 9
       },
       {
-        "translation": "thrice (with H6471)",
+        "translation": "thrice",
         "count": 4
       },
       {
-        "translation": "threescore and thirteen (with H7657)",
+        "translation": "threescore and thirteen",
         "count": 2
       },
       {
@@ -367272,11 +362830,11 @@
         "count": 1
       },
       {
-        "translation": "forks (with H7053)",
+        "translation": "forks",
         "count": 1
       },
       {
-        "translation": "oftentimes (with H6471)",
+        "translation": "oftentimes",
         "count": 1
       }
     ],
@@ -367343,15 +362901,7 @@
         "count": 73
       },
       {
-        "translation": "(send",
-        "count": null
-      },
-      {
-        "translation": "put",
-        "count": null
-      },
-      {
-        "translation": "...) forth",
+        "translation": "(send, put, ...) forth",
         "count": 54
       },
       {
@@ -367481,10 +363031,6 @@
       {
         "translation": "plant",
         "count": 1
-      },
-      {
-        "translation": "put them off",
-        "count": null
       }
     ],
     "outline_definitions": [
@@ -367679,15 +363225,7 @@
         "count": 4
       },
       {
-        "translation": "have power",
-        "count": null
-      },
-      {
-        "translation": "have mastery",
-        "count": null
-      },
-      {
-        "translation": "rule",
+        "translation": "have power, have mastery, rule",
         "count": 1
       }
     ],
@@ -369116,11 +364654,11 @@
     "part_of_speech": "adverb",
     "english_translations": [
       {
-        "translation": "times past (with H8543)",
+        "translation": "times past",
         "count": 7
       },
       {
-        "translation": "heretofore (with H8543)",
+        "translation": "heretofore",
         "count": 6
       },
       {
@@ -369132,12 +364670,8 @@
         "count": 2
       },
       {
-        "translation": "beforetime (with H8543)",
-        "count": 2
-      },
-      {
-        "translation": "beforetime (with H865)",
-        "count": 1
+        "translation": "beforetime",
+        "count": 3
       },
       {
         "translation": "miscellaneous",
@@ -369153,55 +364687,6 @@
       "or שִׁלְשֹׁם shilshôm",
       "from the same as H8028",
       "trebly, i.e. (in time) day before yesterday:— before (that time, -time), excellent things (from the margin), heretofore, three days, time past."
-    ]
-  },
-  {
-    "concord_id": "H8033",
-    "original_word": "שָׁם",
-    "transliteration": "šām",
-    "part_of_speech": "adverb",
-    "english_translations": [
-      {
-        "translation": "there",
-        "count": null
-      },
-      {
-        "translation": "therein",
-        "count": null
-      },
-      {
-        "translation": "thither",
-        "count": null
-      },
-      {
-        "translation": "whither",
-        "count": null
-      },
-      {
-        "translation": "in it",
-        "count": null
-      },
-      {
-        "translation": "thence",
-        "count": null
-      },
-      {
-        "translation": "thereout",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "there, thither",
-      "there",
-      "thither (after verbs of motion)",
-      "from there, thence",
-      "then (as an adverb of time)"
-    ],
-    "strongs_definition": [
-      "שָׁם shâm, shawm",
-      "a primitive particle (rather from the relative pronoun, H834)",
-      "there (transferring to time) then",
-      "often thither, or thence:—in it, thence, there (-in, of, out), thither, whither."
     ]
   },
   {
@@ -369224,22 +364709,14 @@
       },
       {
         "translation": "famous",
-        "count": 3
+        "count": 4
       },
       {
         "translation": "named",
-        "count": 3
+        "count": 5
       },
       {
-        "translation": "named (with H7121)",
-        "count": 2
-      },
-      {
-        "translation": "famous (with H7121)",
-        "count": 1
-      },
-      {
-        "translation": "infamous (with H2931)",
+        "translation": "infamous",
         "count": 1
       },
       {
@@ -369299,7 +364776,7 @@
         "count": 11
       },
       {
-        "translation": "named (with H7761)",
+        "translation": "named",
         "count": 1
       }
     ],
@@ -370102,7 +365579,7 @@
         "count": 21
       },
       {
-        "translation": "astrologers (with H1895)",
+        "translation": "astrologers",
         "count": 1
       }
     ],
@@ -370654,11 +366131,11 @@
         "count": 74
       },
       {
-        "translation": "eighteen (with H6240)",
+        "translation": "eighteen",
         "count": 18
       },
       {
-        "translation": "eighteenth (with H6240)",
+        "translation": "eighteenth",
         "count": 11
       },
       {
@@ -370666,7 +366143,7 @@
         "count": 5
       },
       {
-        "translation": "eighteen thousand (with H7239)",
+        "translation": "eighteen thousand",
         "count": 1
       }
     ],
@@ -371767,11 +367244,11 @@
         "count": 119
       },
       {
-        "translation": "sunrising (with H4217)",
+        "translation": "sunrising",
         "count": 9
       },
       {
-        "translation": "east side (with H4217)",
+        "translation": "east side",
         "count": 2
       },
       {
@@ -371779,15 +367256,15 @@
         "count": 1
       },
       {
-        "translation": "eastward (with H4217)",
+        "translation": "eastward",
         "count": 1
       },
       {
-        "translation": "west (with H3996)",
+        "translation": "west",
         "count": 1
       },
       {
-        "translation": "westward (with H3996)",
+        "translation": "westward",
         "count": 1
       }
     ],
@@ -372334,7 +367811,7 @@
     "english_translations": [
       {
         "translation": "year",
-        "count": 797
+        "count": 798
       },
       {
         "translation": "not translated",
@@ -372342,22 +367819,14 @@
       },
       {
         "translation": "yearly",
-        "count": 3
+        "count": 5
       },
       {
-        "translation": "yearly (with H8141)",
-        "count": 2
-      },
-      {
-        "translation": "year (with H1121)",
+        "translation": "live",
         "count": 1
       },
       {
-        "translation": "live (with H2416)",
-        "count": 1
-      },
-      {
-        "translation": "old (with H2416) (with H3117)",
+        "translation": "old",
         "count": 1
       },
       {
@@ -372428,11 +367897,7 @@
     "english_translations": [
       {
         "translation": "scarlet",
-        "count": 34
-      },
-      {
-        "translation": "scarlet (with H8438)",
-        "count": 5
+        "count": 39
       },
       {
         "translation": "scarlet thread",
@@ -372536,7 +368001,7 @@
         "count": 533
       },
       {
-        "translation": "twelve (with H6240)",
+        "translation": "twelve",
         "count": 105
       },
       {
@@ -372544,7 +368009,7 @@
         "count": 69
       },
       {
-        "translation": "twelfth (with H6240)",
+        "translation": "twelfth",
         "count": 21
       },
       {
@@ -372854,7 +368319,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "clovenfooted (with H8156)",
+        "translation": "clovenfooted",
         "count": 3
       },
       {
@@ -373449,7 +368914,7 @@
         "count": 1
       },
       {
-        "translation": "affrighted (with H270)",
+        "translation": "affrighted",
         "count": 1
       },
       {
@@ -373518,7 +368983,7 @@
     "part_of_speech": "masculine noun",
     "english_translations": [
       {
-        "translation": "hundredfold (with H3967)",
+        "translation": "hundredfold",
         "count": 1
       }
     ],
@@ -376521,7 +371986,7 @@
         "count": 1
       },
       {
-        "translation": "shoelatchet (with H5275)",
+        "translation": "shoelatchet",
         "count": 1
       }
     ],
@@ -377776,11 +373241,11 @@
         "count": 187
       },
       {
-        "translation": "sixteen (with H6240)",
-        "count": 21
+        "translation": "sixteen",
+        "count": 22
       },
       {
-        "translation": "sixteenth (with H6240)",
+        "translation": "sixteenth",
         "count": 3
       },
       {
@@ -377788,11 +373253,7 @@
         "count": 2
       },
       {
-        "translation": "sixteen (with H7657)",
-        "count": 1
-      },
-      {
-        "translation": "threescore (with H7239)",
+        "translation": "threescore",
         "count": 1
       }
     ],
@@ -378996,10 +374457,10 @@
       },
       {
         "translation": "goodly",
-        "count": 2
+        "count": 3
       },
       {
-        "translation": "beautiful (with H3303)",
+        "translation": "beautiful",
         "count": 2
       },
       {
@@ -379015,11 +374476,7 @@
         "count": 1
       },
       {
-        "translation": "fair (with H3303)",
-        "count": 1
-      },
-      {
-        "translation": "goodly (with H2896)",
+        "translation": "fair",
         "count": 1
       },
       {
@@ -380590,7 +376047,7 @@
         "count": 2
       },
       {
-        "translation": "chapmen (with H582)",
+        "translation": "chapmen",
         "count": 1
       },
       {
@@ -380606,7 +376063,7 @@
         "count": 1
       },
       {
-        "translation": "merchantmen (with H582)",
+        "translation": "merchantmen",
         "count": 1
       }
     ],
@@ -381406,69 +376863,6 @@
       "תַּחַשׁ Tachash, takh'-ash",
       "the same as H8476",
       "Tachash, a relative of Abraham:—Thahash."
-    ]
-  },
-  {
-    "concord_id": "H8478",
-    "original_word": "תַּחַת",
-    "transliteration": "taḥaṯ",
-    "part_of_speech": "proper patrial adjective, accusative adverb, masculine noun",
-    "english_translations": [
-      {
-        "translation": "instead",
-        "count": null
-      },
-      {
-        "translation": "under",
-        "count": null
-      },
-      {
-        "translation": "for",
-        "count": null
-      },
-      {
-        "translation": "as",
-        "count": null
-      },
-      {
-        "translation": "with",
-        "count": null
-      },
-      {
-        "translation": "from",
-        "count": null
-      },
-      {
-        "translation": "flat",
-        "count": null
-      },
-      {
-        "translation": "in the same place",
-        "count": null
-      }
-    ],
-    "outline_definitions": [
-      "the under part, beneath, instead of, as, for, for the sake of, flat, unto, where, whereas",
-      "the under part",
-      "beneath",
-      "under, beneath",
-      "at the foot of (idiom)",
-      "sweetness, subjection, woman, being burdened or oppressed (fig)",
-      "of subjection or conquest",
-      "what is under one, the place in which one stands",
-      "in one's place, the place in which one stands (idiom with reflexive pronoun)",
-      "in place of, instead of (in transferred sense)",
-      "in place of, in exchange or return for (of things mutually interchanged)",
-      "instead of, instead of that",
-      "in return for that, because that",
-      "in, under, into the place of (after verbs of motion)",
-      "from under, from beneath, from under the hand of, from his place, under, beneath"
-    ],
-    "strongs_definition": [
-      "תַּחַת tachath, takh'-ath",
-      "from the same as H8430",
-      "the bottom (as depressed)",
-      "only adverbially, below (often with prepositional prefix underneath), in lieu of, etc.:—as, beneath, × flat, in(-stead), (same) place (where...is), room, for...sake, stead of, under, × unto, × when...was mine, whereas, (where-) fore, with."
     ]
   },
   {
@@ -383087,11 +378481,11 @@
     "part_of_speech": "adverb",
     "english_translations": [
       {
-        "translation": "times past (with H8032)",
+        "translation": "times past",
         "count": 7
       },
       {
-        "translation": "heretofore (with H8032)",
+        "translation": "heretofore",
         "count": 6
       },
       {
@@ -383103,7 +378497,7 @@
         "count": 3
       },
       {
-        "translation": "beforetime (with H8032)",
+        "translation": "beforetime",
         "count": 2
       },
       {
@@ -386030,7 +381424,7 @@
     "part_of_speech": "masculine/feminine noun",
     "english_translations": [
       {
-        "translation": "twelve (with H6236)",
+        "translation": "twelve",
         "count": 2
       },
       {
@@ -386647,11 +382041,11 @@
         "count": 6
       },
       {
-        "translation": "nineteenth (with H6240)",
+        "translation": "nineteenth",
         "count": 4
       },
       {
-        "translation": "nineteen (with H6240)",
+        "translation": "nineteen",
         "count": 3
       }
     ],


### PR DESCRIPTION
Strip "(with GXXXX)" / "(with HXXXX)" Strong's cross-reference suffixes from English translation strings, merge the duplicates this creates by summing their counts, and drop entries with `count: null`.