### PR TITLE
Replace q-string search with criterion-based POST endpoint

### DIFF
--- a/apps/bible/schemas.py
+++ b/apps/bible/schemas.py
@@ -1,6 +1,6 @@
 """Pydantic schemas used by the bible app's HTTP handlers."""
 
-from typing import Any, Literal, Union
+from typing import Annotated, Any, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -44,6 +44,84 @@ class VersesQuery(BaseModel):
         if parsed < 1:
             raise ValueError("must be '*' or a positive integer")
         return parsed
+
+
+class _TextCriterion(BaseModel):
+    type: Literal["text"]
+    value: str = Field(min_length=1)
+
+
+class _EnglishCriterion(BaseModel):
+    type: Literal["english"]
+    value: str = Field(min_length=1)
+
+
+class _HebrewCriterion(BaseModel):
+    type: Literal["hebrew"]
+    value: str = Field(min_length=1)
+    concordance_id: str = Field(min_length=1)
+
+
+class _GreekCriterion(BaseModel):
+    type: Literal["greek"]
+    value: str = Field(min_length=1)
+    concordance_id: str = Field(min_length=1)
+
+
+class _AuthorCriterion(BaseModel):
+    type: Literal["author"]
+    value: str = Field(min_length=1)
+
+
+class _SpeakerCriterion(BaseModel):
+    type: Literal["speaker"]
+    value: str = Field(min_length=1)
+
+
+class _BookCriterion(BaseModel):
+    type: Literal["book"]
+    value: str
+
+    @field_validator("value")
+    @classmethod
+    def _resolve(cls, value):
+        code = datasets.resolve_book(value)
+        if code is None:
+            raise ValueError(f"unknown book: {value}")
+        return code
+
+
+class _TestamentCriterion(BaseModel):
+    type: Literal["testament"]
+    value: Literal["old", "new"]
+
+
+SearchCriterion = Annotated[
+    Union[
+        _TextCriterion,
+        _EnglishCriterion,
+        _HebrewCriterion,
+        _GreekCriterion,
+        _AuthorCriterion,
+        _SpeakerCriterion,
+        _BookCriterion,
+        _TestamentCriterion,
+    ],
+    Field(discriminator="type"),
+]
+
+
+class SearchRequest(BaseModel):
+    """JSON body for the search endpoint: a non-empty list of criteria AND'd together."""
+
+    criteria: list[SearchCriterion] = Field(min_length=1)
+
+
+class SearchPageQuery(BaseModel):
+    """Pagination params for the search endpoint."""
+
+    page: int = Field(default=1, ge=1)
+    limit: int = Field(default=25, ge=1, le=100)
 
 
 class ConcordanceEntryResponse(BaseModel):

--- a/apps/bible/utilities/search_criteria.py
+++ b/apps/bible/utilities/search_criteria.py
@@ -1,0 +1,103 @@
+"""Apply a list of SearchCriterion to the bible corpus.
+
+Each criterion either *produces* a candidate verse set (``text``, ``english``)
+or *restricts* an existing set (``book``, ``testament``). Multiple criteria
+are AND'd together. Criteria for which we don't yet have data
+(``hebrew``, ``greek``, ``author``, ``speaker``) are silently dropped — the
+TODO comments below mark where each missing data source needs to plug in.
+"""
+
+from functools import lru_cache
+
+from . import bible_locator, datasets, haystack_search
+
+VERSION = "nasb95"
+INTERNAL_CAP = 10000  # max producer hits considered before pagination
+
+
+def combine(criteria, page, limit):
+    """Resolve criteria into (total, page_refs).
+
+    Refs are ``(version, book_code, chapter, verse)`` tuples in canonical order.
+    """
+
+    producers = [c for c in criteria if c.type in {"text", "english"}]
+    restrictors = [c for c in criteria if c.type in {"book", "testament"}]
+
+    if producers:
+        candidate = None
+        for p in producers:
+            hits = _producer_hits(p)
+            candidate = hits if candidate is None else candidate & hits
+            if not candidate:
+                return 0, []
+        for r in restrictors:
+            pred = _restrictor_predicate(r)
+            candidate = {ref for ref in candidate if pred(ref)}
+    elif restrictors:
+        candidate = _enumerate_restrictor_pool(restrictors)
+    else:
+        return 0, []
+
+    sorted_refs = sorted(candidate, key=_canonical_key)
+    total = len(sorted_refs)
+    start = (page - 1) * limit
+    return total, sorted_refs[start : start + limit]
+
+
+def _producer_hits(criterion):
+    if criterion.type == "text":
+        refs = bible_locator.lookup(criterion.value)
+        if refs:
+            return {_normalize(*r) for r in refs}
+        refs = haystack_search.fulltext_lookup(criterion.value, limit=INTERNAL_CAP)
+        return {_normalize(*r) for r in refs}
+    if criterion.type == "english":
+        refs = haystack_search.fulltext_lookup(criterion.value, limit=INTERNAL_CAP)
+        return {_normalize(*r) for r in refs}
+    return set()
+
+
+def _restrictor_predicate(criterion):
+    if criterion.type == "book":
+        target = criterion.value
+        return lambda ref: ref[1] == target
+    if criterion.type == "testament":
+        dataset = "OT" if criterion.value == "old" else "NT"
+        codes = set(datasets.books_in_dataset(dataset))
+        return lambda ref: ref[1] in codes
+    return lambda ref: True
+
+
+def _enumerate_restrictor_pool(restrictors):
+    book_code = "*"
+    dataset = "bible"
+    for c in restrictors:
+        if c.type == "book":
+            book_code = c.value
+        elif c.type == "testament":
+            dataset = "OT" if c.value == "old" else "NT"
+    return {
+        (VERSION, code, ch, v)
+        for code, ch, v in datasets.enumerate_verses(dataset, book_code, "*", "*")
+    }
+
+
+def _normalize(version, book, chapter, verse):
+    return (version, book, int(chapter), int(verse))
+
+
+@lru_cache(maxsize=1)
+def _canon_order():
+    return {code: i for i, code in enumerate(datasets.books_in_dataset("bible"))}
+
+
+def _canonical_key(ref):
+    return (_canon_order().get(ref[1], 999), ref[2], ref[3])
+
+
+# TODO: hebrew / greek criteria need per-verse Strong's concordance tagging in
+# bible.json (each verse gets a list of concord_ids) before we can filter on them.
+# TODO: author criterion needs a book-author mapping (e.g. apps/bible/data/authors.json)
+# that returns the human author for each book code.
+# TODO: speaker criterion needs per-pericope speaker annotation; no data source yet.

--- a/apps/bible/views.py
+++ b/apps/bible/views.py
@@ -1,61 +1,56 @@
 """Implementations of various Bible handlers."""
 
+import json
 import logging
 import random
 
-from django.http import HttpResponse, JsonResponse
+from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
 from django_redis import get_redis_connection
+from pydantic import ValidationError
 
 from lamplight.decorators import validate_params
 
 from .models import ConcordanceEntry
-from .schemas import ConcordanceEntryResponse, VersesQuery
-from .utilities import bible_locator, datasets, haystack_search
+from .schemas import (ConcordanceEntryResponse, SearchPageQuery, SearchRequest,
+                      VersesQuery)
+from .utilities import datasets, search_criteria
 
 logger = logging.getLogger(__name__)
 
 
+@csrf_exempt
+@require_http_methods(["POST"])
 def search(request):
-    """Search for bible verses given a wide variety of
-    input strings that are interpretted on-the-fly."""
+    """Filter bible verses by an AND'd list of search criteria.
 
-    query = request.GET.get("q")
-    results = []
-    if query:
-        results = bible_locator.lookup(query)
-        if not results:
-            results = haystack_search.fulltext_lookup(query)
+    Request body: ``{"criteria": [SearchCriterion, ...]}``. Query params
+    ``page`` (>=1, default 1) and ``limit`` (1..100, default 25) control
+    pagination. Response: ``{"total": int, "verses": [...]}``.
+    """
 
-    if not results:
-        return HttpResponse(status=204)
+    try:
+        body = json.loads(request.body or b"{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "body must be valid JSON"}, status=400)
 
-    data = []
-    redis_conn = get_redis_connection("default")
-    for result in results:
-        text = redis_conn.hget(
-            f"{result[0]}:{result[1]}:{result[2]}:{result[3]}", "data"
-        )
-        # logger.info(f"{result[0]}:{result[1]}:{result[2]}:{result[3]}")
-        if (
-            text is None
-        ):  # note: none means key doesn't exist, "" is valid for verses like Rev 12:18
-            return HttpResponse(status=404)
+    try:
+        payload = SearchRequest.model_validate(body)
+        page_query = SearchPageQuery.model_validate(request.GET.dict())
+    except ValidationError as exc:
+        first = exc.errors()[0]
+        field = first["loc"][0] if first["loc"] else "input"
+        return JsonResponse({"error": f"{field}: {first['msg']}"}, status=400)
 
-        book_name = redis_conn.hget(f"{result[0]}:{result[1]}", "data")
-        if book_name:
-            data.append(
-                {
-                    "book": " ".join(
-                        word.capitalize() for word in book_name.split(" ")
-                    ),
-                    "chapter": int(result[2]),
-                    "verse": int(result[3]),
-                    "text": text,
-                }
-            )
-
-    return JsonResponse({"data": data}, status=201)
+    total, refs = search_criteria.combine(
+        payload.criteria, page_query.page, page_query.limit
+    )
+    verses_out = _hydrate_verses(
+        [(code, ch, v) for _, code, ch, v in refs], search_criteria.VERSION
+    )
+    return JsonResponse({"total": total, "verses": verses_out})
 
 
 @validate_params(VersesQuery, path_fields=("book", "chapter", "verse"))

--- a/tests/test_bible_search.py
+++ b/tests/test_bible_search.py
@@ -1,80 +1,209 @@
-"""Test the various high level search functionality and define its edge cases."""
+"""Tests for the criterion-based search endpoint."""
 
-from urllib.parse import urlencode
+import json
 
 import pytest
 from django.urls import reverse
 
 
+def _post(client, criteria, query=""):
+    url = reverse("search")
+    if query:
+        url = f"{url}?{query}"
+    return client.post(
+        url,
+        data=json.dumps({"criteria": criteria}),
+        content_type="application/json",
+    )
+
+
 @pytest.mark.parametrize(
-    "text_input",
+    "value,book,chapter,verse",
     [
         ("Luke 1:28", "Luke", 1, 28),
-        ("Luke 1", "Luke", 1),
-        ("Luk 1", "Luke", 1),
-        ("Luk1", "Luke", 1),
-        ("luk1", "Luke", 1),
-        ("luk      1", "Luke", 1),
         ("Matt 8:28", "Matthew", 8, 28),
         ("Rev 12:18", "Revelation", 12, 18),
         ("1 John 3:16", "1 John", 3, 16),
         ("song of songs 1:15", "Song Of Songs", 1, 15),
         ("1JOhn 3:16", "1 John", 3, 16),
-        ("inasmuch", "Hebrews", 7, 20),
-        ("priestly", "Luke", 1, 23),
-        ("Do not be afraid, Zacharias", "Luke", 1, 13),
-        ("for God so loved the world", "John", 3, 16),
-        ("Jesus wept", "John", 11, 35),
     ],
 )
-def test_standard_query_strings(text_input, client):
-    """Test good input search strings."""
-
-    response = client.post(f'{reverse("search")}?{urlencode({"q": text_input[0]})}')
-    assert response.status_code == 201
-
+def test_text_criterion_verse_refs(client, value, book, chapter, verse):
+    """A text criterion containing a verse reference resolves to that exact verse."""
+    response = _post(client, [{"type": "text", "value": value}])
+    assert response.status_code == 200
     out = response.json()
-    if len(text_input) > 1:
-        assert out["data"][0]["book"] == text_input[1]
-    if len(text_input) > 2:
-        assert out["data"][0]["chapter"] == text_input[2]
-    if len(text_input) > 3:
-        assert out["data"][0]["verse"] == text_input[3]
-    assert out["data"][0]["text"] is not None
+    first = out["verses"][0]
+    assert first["book"] == book
+    assert first["chapter"] == chapter
+    assert first["verse"] == verse
+    assert first["text"] is not None
 
 
 @pytest.mark.parametrize(
-    "text_input",
+    "value,book,chapter,verse",
     [
         ("Luek 1:28", "Luke", 1, 28),
         ("ulke 1:28", "Luke", 1, 28),
         ("lk 1:28", "Luke", 1, 28),
     ],
 )
-def test_misspelled_verse(text_input, client):
-    """Test good input search strings."""
-
-    response = client.post(f'{reverse("search")}?{urlencode({"q": text_input[0]})}')
-    assert response.status_code == 201
-
-    out = response.json()
-    assert out["data"][0]["book"] == text_input[1]
-    assert out["data"][0]["chapter"] == text_input[2]
-    assert out["data"][0]["verse"] == text_input[3]
+def test_text_criterion_misspelled(client, value, book, chapter, verse):
+    """Misspelled or abbreviated book names in a text criterion still resolve correctly."""
+    response = _post(client, [{"type": "text", "value": value}])
+    assert response.status_code == 200
+    first = response.json()["verses"][0]
+    assert first["book"] == book
+    assert first["chapter"] == chapter
+    assert first["verse"] == verse
 
 
 @pytest.mark.parametrize(
-    "text_input",
+    "value,book,chapter,verse",
     [
-        "Luke 0:28",
-        "Luke 100:28",
-        "Luke -1:28",
-        "Luke 1:-1",
-        "Luke 1:110",
+        ("inasmuch", "Hebrews", 7, 20),
+        ("priestly", "Luke", 1, 23),
+        ("for God so loved the world", "John", 3, 16),
+        ("Jesus wept", "John", 11, 35),
     ],
 )
-def test_bad_verse_numbers(text_input, client):
-    """Test good input search strings."""
+def test_text_criterion_fulltext(client, value, book, chapter, verse):
+    """A text criterion that isn't a verse reference falls back to full-text search."""
+    response = _post(client, [{"type": "text", "value": value}])
+    assert response.status_code == 200
+    verses = response.json()["verses"]
+    assert any(
+        v["book"] == book and v["chapter"] == chapter and v["verse"] == verse
+        for v in verses
+    )
 
-    response = client.post(f'{reverse("search")}?{urlencode({"q": text_input})}')
-    assert response.status_code == 404
+
+def test_english_criterion_returns_fulltext_hits(client):
+    """The english criterion performs a full-text search and returns matching verses."""
+    response = _post(client, [{"type": "english", "value": "love"}])
+    assert response.status_code == 200
+    out = response.json()
+    assert out["total"] > 0
+    assert all("text" in v for v in out["verses"])
+
+
+def test_book_only_returns_first_page_of_book(client):
+    """A lone book criterion returns the book's verses starting from chapter 1, verse 1."""
+    response = _post(client, [{"type": "book", "value": "John"}], query="limit=10")
+    assert response.status_code == 200
+    out = response.json()
+    assert out["total"] > 10
+    assert len(out["verses"]) == 10
+    assert all(v["book"] == "John" for v in out["verses"])
+    assert out["verses"][0]["chapter"] == 1
+    assert out["verses"][0]["verse"] == 1
+
+
+def test_testament_only_starts_at_genesis(client):
+    """A lone Old Testament criterion returns verses beginning at Genesis 1:1."""
+    response = _post(client, [{"type": "testament", "value": "old"}], query="limit=5")
+    assert response.status_code == 200
+    out = response.json()
+    assert out["total"] > 5
+    assert out["verses"][0]["book"] == "Genesis"
+    assert out["verses"][0]["chapter"] == 1
+    assert out["verses"][0]["verse"] == 1
+
+
+def test_combined_producer_and_restrictor(client):
+    """A book restrictor combined with a text producer filters results to that book."""
+    response = _post(
+        client,
+        [
+            {"type": "text", "value": "love"},
+            {"type": "book", "value": "John"},
+        ],
+    )
+    assert response.status_code == 200
+    out = response.json()
+    assert out["total"] > 0
+    assert all(v["book"] == "John" for v in out["verses"])
+
+
+def test_pagination_advances_through_results(client):
+    """Requesting page 2 yields a different slice of verses than page 1 with the same total."""
+    page1 = _post(client, [{"type": "book", "value": "John"}], query="page=1&limit=5")
+    page2 = _post(client, [{"type": "book", "value": "John"}], query="page=2&limit=5")
+    assert page1.status_code == 200
+    assert page2.status_code == 200
+    p1 = page1.json()
+    p2 = page2.json()
+    assert p1["total"] == p2["total"]
+    assert len(p1["verses"]) == 5
+    assert len(p2["verses"]) == 5
+    assert p1["verses"][0] != p2["verses"][0]
+
+
+def test_ignored_only_returns_empty(client):
+    """A criterion that produces no verses on its own (e.g. author) yields an empty result."""
+    response = _post(client, [{"type": "author", "value": "Paul"}])
+    assert response.status_code == 200
+    assert response.json() == {"total": 0, "verses": []}
+
+
+def test_ignored_alongside_producer_does_not_affect_results(client):
+    """A non-restricting criterion paired with a producer leaves it unchanged."""
+    base = _post(client, [{"type": "text", "value": "Jesus wept"}])
+    mixed = _post(
+        client,
+        [
+            {"type": "text", "value": "Jesus wept"},
+            {"type": "hebrew", "value": "ab", "concordance_id": "H0001"},
+        ],
+    )
+    assert base.status_code == 200
+    assert mixed.status_code == 200
+    assert base.json() == mixed.json()
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["Luke 0:28", "Luke 100:28", "Luke -1:28", "Luke 1:-1", "Luke 1:110"],
+)
+def test_out_of_range_verse_refs_return_empty(client, value):
+    """Verse references outside the book's chapter/verse range return an empty result set."""
+    response = _post(client, [{"type": "text", "value": value}])
+    assert response.status_code == 200
+    assert response.json()["verses"] == []
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {},  # criteria missing
+        {"criteria": []},  # empty list
+        {"criteria": [{"type": "unknown", "value": "x"}]},
+        {"criteria": [{"type": "text"}]},  # missing value
+        {"criteria": [{"type": "book", "value": "Notabook"}]},
+        {"criteria": [{"type": "hebrew", "value": "ab"}]},  # missing concordance_id
+    ],
+)
+def test_bad_payload_returns_400(client, body):
+    """Malformed or unrecognized criteria payloads are rejected with HTTP 400."""
+    response = client.post(
+        reverse("search"),
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+
+
+def test_invalid_json_returns_400(client):
+    """A request body that isn't valid JSON is rejected with HTTP 400."""
+    response = client.post(
+        reverse("search"),
+        data="not-json",
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+
+
+def test_get_method_not_allowed(client):
+    """The search endpoint accepts POST only; GET returns HTTP 405."""
+    response = client.get(reverse("search"))
+    assert response.status_code == 405


### PR DESCRIPTION
Search now accepts an AND'd list of typed criteria (text, english, book, testament, plus stubs for hebrew/greek/author/speaker) with pagination, enabling combined filters like "love in John" that the single q-string couldn't express.